### PR TITLE
Fix for C-c t command

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -231,8 +231,12 @@ Retuns the problem overlay if such a position is found, otherwise nil."
 (defun clojure-test-implementation-for (namespace)
   (let* ((namespace (clojure-underscores-for-hyphens namespace))
          (segments (split-string namespace "\\."))
-         (before (subseq segments 0 clojure-test-ns-segment-position))
-         (after (subseq segments (1+ clojure-test-ns-segment-position)))
+         (test-position
+          (if (> 0 clojure-test-ns-segment-position)
+              (1- (+ (length segments) clojure-test-ns-segment-position))
+            clojure-test-ns-segment-position))
+         (before (subseq segments 0 test-position))
+         (after (subseq segments (1+ test-position)))
          (impl-segments (append before after)))
     (mapconcat 'identity impl-segments "/")))
 


### PR DESCRIPTION
Hello, I thought I had already sent this request, but I can't see it in my queue -- apologies if you get this twice.

Just a small fix for people using negative values for clojure-test-ns-segment-position: looks like clojure-test-implementation-for hadn't been updated to handle it.
