### PR TITLE
Fix to record-literal patch, and more

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -118,7 +118,6 @@ Clojure to load that file."
     (modify-syntax-entry ?\[ "(]" table)
     (modify-syntax-entry ?\] ")[" table)
     (modify-syntax-entry ?^ "'" table)
-    (modify-syntax-entry ?= "'" table)
     table))
 
 (defvar clojure-mode-abbrev-table nil


### PR DESCRIPTION
Explanation of first commit:

Suppose the buffer contains `[[]|]`, where `|` denotes point. `M-x backward-sexp` transitions the buffer to `[|[]]`, as expected, but prints a warning: `forward-sexp: Scan error: "Containing expression ends prematurely", 1, 1`. This is because my redefinition of `forward-sexp` involves calling `backward-sexp` inside an excursion to determine if the next sexp looks like a record literal. However, the scan error signals a condition, causing the whole function to abort.

This might be acceptable at some level, since aside from the undesired message, the function behaves as expected. However, when paredit is active, `C-M-b` is rebound to `paredit-backward`, which handles the condition by moving a level up in the sexp, resulting in `|[[]]`. Aside from being wrong in this context, it has undesirable effects on other things, such as `splice-killing-backward`, which make paredit basically unusable.

So I need to catch the scan-error condition myself. I've done that in [db9080](https://github.com/amalloy/clojure-mode/commit/db9080) - it's starting to look a little hacky but is probably still worth pulling.

Explanation of second commit:

**However**, while working on this I came across a strange issue with paredit/clojure-mode interaction. Consider the following buffer, again with `|` denoting point:

```
(= 1
   |(reduce + whatever))
```

At this point, `M-UP` should splice away the equality-test entirely, leaving only the reduce form. And indeed this is what happens if the buffer is in lisp mode. In clojure mode, however, I am left with

```
= (reduce + whatever)
```

I can reproduce this error on commit [b5339](https://github.com/amalloy/clojure-mode/commit/b5339), before I started my changes, so I don't think I caused this.

If I replace `=` with `f`, it works as expected; contrarily, replacing it with `==` doesn't fix things. So it looks like an issue with non-alphanumeric symbols. Perhaps `=` isn't in the right part of the syntax table, I wondered? I took a look, and there's an entry for `=`, for some reason as an "expression quote or prefix operator". I removed that and it now works as expected. I don't understand why `=` was ever treated specially, though, so I may be breaking something elsewhere. If so, this still needs to be fixed. 

I did a little research, and it looks like the change to `=` is pretty recent: commit [9acca](https://github.com/amalloy/clojure-mode/commit/9acca) in February 2010. I still don't get it after looking at the commit note, so my vote is to roll it back by pulling [adc2cf](https://github.com/amalloy/clojure-mode/commit/adc2cf) as well.
