### PR TITLE
Expand file name before passing to shell-command (cross-platform bug)

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -843,7 +843,7 @@ use (put-clojure-indent 'some-symbol 'defun)."
       (setq clojure-root (if ido-mode
                              (ido-read-directory-name "Project: ")
                            (read-directory-name "Project: "))))
-    (shell-command (format clojure-swank-command clojure-root clojure-swank-port)
+    (shell-command (format clojure-swank-command (expand-file-name clojure-root) clojure-swank-port)
                    "*swank*")
     (set-process-filter (get-buffer-process "*swank*")
                         (lambda (process output)


### PR DESCRIPTION
Per ticket #52 on swank-clojure's project, this fixes the Windows bug whereby the `clojure-root` is sent as a relative path with `~` to `shell-command` which doesn't work on Windows.

Thanks, Phil.
