### PR TITLE
Highlight all def* forms the same?

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -357,7 +357,7 @@ elements of a def* forms."
             "gen-class" "gen-and-load-class" "gen-and-save-class"
             "handler-case" "handle") t)
          "\\>")
-       .  1)
+       1 font-lock-builtin-face)
       ;; Built-ins
       (,(concat
          "(\\(?:clojure.core/\\)?"
@@ -465,7 +465,7 @@ elements of a def* forms."
         "with-meta" "with-open" "with-out-str" "with-precision" "xml-seq"
         ) t)
          "\\>")
-       1 font-lock-builtin-face)
+       1 font-lock-variable-name-face)
       ;; (fn name? args ...)
       (,(concat "(\\(?:clojure.core/\\)?\\(fn\\)[ \t]+"
                 ;; Possibly type
@@ -515,7 +515,7 @@ elements of a def* forms."
          "\\>")
        1 font-lock-type-face)
       ;; Constant values (keywords), including as metadata e.g. ^:static
-      ("\\<^?:\\(\\sw\\|#\\)+\\>" 0 font-lock-builtin-face)
+      ("\\<^?:\\(\\sw\\|#\\)+\\>" 0 font-lock-constant-face)
       ;; Meta type annotation #^Type or ^Type
       ("#?^\\sw+" 0 font-lock-type-face)
       ("\\<io\\!\\>" 0 font-lock-warning-face)
@@ -799,7 +799,7 @@ use (put-clojure-indent 'some-symbol 'defun)."
                                       (one-or-more (not (any whitespace)))))
                     (one-or-more (any whitespace "\n")))
       ;; why is this here? oh (in-ns 'foo) or (ns+ :user)
-      (zero-or-one (any ":'"))         
+      (zero-or-one (any ":'"))
       (group (one-or-more (not (any "()\"" whitespace))) word-end)))
 
 ;; for testing *namespace-name-regex*, you can evaluate this code and make
@@ -808,7 +808,7 @@ use (put-clojure-indent 'some-symbol 'defun)."
 ;; (mapcar (lambda (s) (let ((n (string-match *namespace-name-regex* s)))
 ;;                       (if n (match-string 4 s))))
 ;;         '("(ns foo)"
-;;           "(ns 
+;;           "(ns
 ;; foo)"
 ;;           "(ns foo.baz)"
 ;;           "(ns ^:bar foo)"


### PR DESCRIPTION
What do you guys think about just highlighting any form that starts with `(def*` as a function definition?

I'm not certain this is a good idea, as highlighting seems to indicate a symbol is part of the language, but it has been helpful for me as I add my own def forms in my projects. Kind of analogous to indenting all `(with-*` forms the same...
