### PR TITLE
Fix for issue #21

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -523,7 +523,7 @@ elements of a def* forms."
         "path" "prev" "remove" "replace" "right"
         "rightmost" "rights" "root" "seq-zip" "up"
         ) t)
-         "\\>")
+         "\\(\\>\\|\\_>\\)")
        1 font-lock-type-face)
       ;; Constant values (keywords), including as metadata e.g. ^:static
       ("\\<^?:\\(\\sw\\|\\s_\\)+\\(?:\\>\\|\\_>\\)" 0 font-lock-constant-face)


### PR DESCRIPTION
This fix allows for an octothorpe or quote as a symbol constituent character, and updates the font lock regexen to match.

According to my tests the octothorphe was allowed as a symbol constituent character in Clojure 1.2 as long as it wasn't the first character in a symbol, and in the case of a keyword it could be used anywhere in the keyword's name.

As of Clojure 1.3, the quote is allowed as a symbol constituent character as long as it isn't the first character in the symbol, and in the case of a keyword it can be used anywhere in the keyword's name.

I believe this patch is correct with repect to these situations.

One drawback with this patch is that it allows the quote as a symbol constituent character without regard to the Clojure version. That may be undesirable, but I'm not sure the best way to handle that (or if it's possible).
