### PR TITLE
Fix for #31.

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -189,7 +189,7 @@
                                                    ((file-position 3) 1)
                                                    (:line event)))])))
      (binding [*test-out* *out*]
-       ((.getRoot #'clojure.test/report) event)))
+       ((.getRawRoot #'clojure.test/report) event)))
 
    (defn clojure-test-mode-test-one-var [test-ns test-name]
      (let [v (ns-resolve test-ns test-name)
@@ -269,29 +269,29 @@
   "Go to the next position with an overlay message.
 Retuns the problem overlay if such a position is found, otherwise nil."
   (let ((current-overlays (overlays-at here))
-	(next-overlays (next-overlay-change here)))
+        (next-overlays (next-overlay-change here)))
     (while (and (not (equal next-overlays (point-max)))
-		(or
-		 (not (overlays-at next-overlays))
-		 (equal (overlays-at next-overlays)
-			current-overlays)))
+                (or
+                 (not (overlays-at next-overlays))
+                 (equal (overlays-at next-overlays)
+                        current-overlays)))
       (setq next-overlays (next-overlay-change next-overlays)))
     (if (not (equal next-overlays (point-max)))
-	(overlay-start (car (overlays-at next-overlays))))))
+        (overlay-start (car (overlays-at next-overlays))))))
 
 (defun clojure-test-find-previous-problem (here)
   "Go to the next position with the `clojure-test-problem' text property.
 Retuns the problem overlay if such a position is found, otherwise nil."
   (let ((current-overlays (overlays-at here))
-	(previous-overlays (previous-overlay-change here)))
+        (previous-overlays (previous-overlay-change here)))
     (while (and (not (equal previous-overlays (point-min)))
-		(or
-		 (not (overlays-at previous-overlays))
-		 (equal (overlays-at previous-overlays)
-			current-overlays)))
+                (or
+                 (not (overlays-at previous-overlays))
+                 (equal (overlays-at previous-overlays)
+                        current-overlays)))
       (setq previous-overlays (previous-overlay-change previous-overlays)))
     (if (not (equal previous-overlays (point-min)))
-	(overlay-start (car (overlays-at previous-overlays))))))
+        (overlay-start (car (overlays-at previous-overlays))))))
 
 ;; File navigation
 
@@ -334,7 +334,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
   (clojure-test-clear
    (lambda (&rest args)
      (let* ((f (which-function))
-	    (test-name (if (listp f) (first f) f)))
+            (test-name (if (listp f) (first f) f)))
        (slime-eval-async
         `(swank:interactive-eval
           ,(format "(binding [clojure.test/report clojure.test.mode/report]
@@ -347,7 +347,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
         (lambda (result-str)
           (let ((result (read result-str)))
             (if (cdr result)
-		(clojure-test-extract-result result)
+                (clojure-test-extract-result result)
               (message "Not in a test.")))))))))
 
 (defun clojure-test-show-result ()
@@ -376,7 +376,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
   "Go to and describe the next test problem in the buffer."
   (interactive)
   (let* ((here (point))
-	 (problem (clojure-test-find-next-problem here)))
+         (problem (clojure-test-find-next-problem here)))
     (if problem
         (goto-char problem)
       (goto-char here)
@@ -386,7 +386,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
   "Go to and describe the previous compiler problem in the buffer."
   (interactive)
   (let* ((here (point))
-	 (problem (clojure-test-find-previous-problem here)))
+         (problem (clojure-test-find-previous-problem here)))
     (if problem
         (goto-char problem)
       (goto-char here)
@@ -425,7 +425,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
 ;;;###autoload
 (progn
   (defun clojure-test-maybe-enable ()
-    "Enable clojure-test-mode if the current buffer contains a namespace 
+    "Enable clojure-test-mode if the current buffer contains a namespace
 with a \"test.\" bit on it."
     (let ((ns (clojure-find-package))) ; defined in clojure-mode.el
       (when (search "test." ns)


### PR DESCRIPTION
Use .getRawRoot against vars, as .getRoot disappeared in Clojure 1.3. References #31.

Should be a safe change: .getRawRoot differs from .getRoot only in that .getRawRoot will not throw if the var has no root. Given that .getRoot is used in clojure-test-mode only against clojure.test/report, and that report is defined as part of the public API of clojure.test, that seems like a reasonable risk to take.
