### PR TITLE
Fix for #35, highlighting correct test failure when narrowing is in effect

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -255,7 +255,7 @@
 
 (defun clojure-test-highlight-problem (line event message)
   (save-excursion
-    (goto-char (point-min)) (forward-line (1- line))
+    (goto-line line)
     (let ((beg (point)))
       (end-of-line)
       (let ((overlay (make-overlay beg (point))))


### PR DESCRIPTION
Highlight the correct test failure/error when narrowing is in effect (fixes #35, see discussion there).
