### PR TITLE
Make sexp parsing consistent with other lisp modes (fixes #34)

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -182,6 +182,7 @@ if that value is non-nil."
          'clojure-forward-sexp))
   (set (make-local-variable 'lisp-doc-string-elt-property)
        'clojure-doc-string-elt)
+  (set (make-local-variable 'parse-sexp-ignore-comments) t)
 
   (clojure-mode-font-lock-setup)
 


### PR DESCRIPTION
Without this, individual words within comments are considered sexps, and this breaks `check-parens` under Emacs 24 when a ")" is contained in a comment.
