### PR TITLE
Add put-clojure-indent to slime-indentation-update-hooks

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -952,6 +952,8 @@ use (put-clojure-indent 'some-symbol 'defun)."
 ;;;###autoload
 (add-hook 'slime-connected-hook 'clojure-enable-slime-on-existing-buffers)
 
+(add-hook 'slime-indentation-update-hooks 'put-clojure-indent)
+
 
 
 ;;;###autoload


### PR DESCRIPTION
Allow swank to update the indentation of forms via :indentation-update messages.
