### PR TITLE
To properly indent finally expression

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -763,6 +763,7 @@ use (put-clojure-indent 'some-symbol 'defun)."
 
   (try 0)
   (catch 2)
+  (finally 0)
 
   ;; binding forms
   (let 1)


### PR DESCRIPTION
Added (finally 0) to define-clojure-indent to properly indent finally expression.

Before change the lines inside a finally expression were indented a single space. With change they are intended 2 spaces. Evidently 'finally' was left out of try / catch handling.
