### PR TITLE
Fix error when no namespace in clojure-test-maybe-enable.

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -433,7 +433,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
     "Enable clojure-test-mode if the current buffer contains a namespace
 with a \"test.\" bit on it."
     (let ((ns (clojure-find-package))) ; defined in clojure-mode.el
-      (when (string-match-p "test\\(\\.\\|$\\)" ns)
+      (when (and ns (string-match "test\\(\\.\\|$\\)" ns))
         (save-window-excursion
           (clojure-test-mode t)))))
   (add-hook 'clojure-mode-hook 'clojure-test-maybe-enable))


### PR DESCRIPTION
- string-match-p raise error when ns is nil.
- emacs 22 doesn't have string-match-p, so use string-match.
