### PR TITLE
error: "Symbol's function definition is void: slime-tramp-local-filename"

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1170,9 +1170,9 @@ The arguments are dir, hostname, and port.  The return value should be an `alist
 
 (defun clojure-slime-remote-file-name-hook ()
   (setq slime-from-lisp-filename-function
-        'slime-tramp-remote-filename)
+        'clojure-slime-tramp-remote-filename)
   (setq slime-to-lisp-filename-function
-        'slime-tramp-local-filename))
+        'clojure-slime-tramp-local-filename))
 
 (add-hook 'slime-connected-hook 'clojure-slime-remote-file-name-hook)
 


### PR DESCRIPTION
Pull request #62 broke clojure-mode for me:
https://github.com/technomancy/clojure-mode/commit/52cd75c8fb733f472d60a4a7fdf3205c3703d8cb

When I do clojure-jack-in, I'm prevented from editing the .clj file I was working on. Emacs shows the error: "Symbol's function definition is void: slime-tramp-local-filename"

I think this is just a typo in the names of the functions being set in clojure-slime-remote-file-name-hook.
