### PR TITLE
Highlight definer forms

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -349,6 +349,16 @@ elements of a def* forms."
                 ;; Possibly type or metadata
                 "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
                 "\\(\\sw+\\)?")
+       (1 font-lock-type-face)
+       (2 font-lock-function-name-face nil t))
+      (,(concat "\\(\\(?:[a-z\.-]+/\\)?def\[a-z\]*-?\\)"
+                ;; Function declarations.
+                "\\>"
+                ;; Any whitespace
+                "[ \r\n\t]*"
+                ;; Possibly type or metadata
+                "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
+                "\\(\\sw+\\)?")
        (1 font-lock-keyword-face)
        (2 font-lock-function-name-face nil t))
       ;; Deprecated functions


### PR DESCRIPTION
I thought it would be nice if things like Compojure's `defroutes` got treated like a Clojure `def*` form. To differentiate between the Clojure core forms, I changed their highlight.
