### PR TITLE
Indentation for use-fixtures

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -805,6 +805,7 @@ use (put-clojure-indent 'some-symbol 'defun)."
   ;; clojure.test
   (testing 1)
   (deftest 'defun)
+  (use-fixtures 'defun)
 
   ;; contrib
   (handler-case 1)


### PR DESCRIPTION
Please to be considering this.

``` clojure
(use-fixtures :once
  (fn [t]
     (t))
  (fn [t]
     (t)))
```

is objectively better than

``` clojure
(use-fixtures :once
              (fn [t]
                (t))
              (fn [t]
                (t)))
```
