### PR TITLE
Bug fix for clojure-insert-ns-form and new clojure-update-ns function

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -965,8 +965,7 @@ returned."
   (goto-char (point-min))
   (insert (format "(ns %s)" (clojure-expected-ns))))
 
-(defun clojure-update-ns
-  ()
+(defun clojure-update-ns ()
   "Updates the namespace of the current buffer. Useful if a file has been renamed."
   (interactive)
   (let ((nsname (clojure-expected-ns)))


### PR DESCRIPTION
As mentioned previously in my mail this is my request to merge a new clojure-update-ns function. The function updates the clojure namespace of the buffer according to its path on the filesystem. This is useful when renaming or moving clojure files on the filesystem.

I also noticed a bug in the clojure-insert-ns-form which does not perform as expected when creating a ns for a file located under the test directory. This is fixed by using the clojure-expected-ns function (which is also used by clojure-update-ns).
