### PR TITLE
fix for clojure-expected-ns and pathnames containing underscore

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -958,7 +958,8 @@ returned."
                        (locate-dominating-file default-directory
                                                "project.clj")))
          (relative (substring (buffer-file-name) (length project-dir) -4)))
-    (mapconcat 'identity (cdr (split-string relative "/")) ".")))
+    (replace-regexp-in-string
+     "_" "-" (mapconcat 'identity (cdr (split-string relative "/")) "."))))
 
 (defun clojure-insert-ns-form ()
   (interactive)


### PR DESCRIPTION
Here is a fix for fix for clojure-expected-ns to make it works for pathnames containing underscore. Sorry I forgot that case on the last push request!
