### PR TITLE
Set indent for this-as

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -794,6 +794,7 @@ use (put-clojure-indent 'some-symbol 'defun)."
   (dotimes 1)
   (when-let 1)
   (if-let 1)
+  (this-as 'defun)
 
   ;; data structures
   (defstruct 1)


### PR DESCRIPTION
This applies to `clojure-mode` as well as `clojurescript-mode`, but that's actually helpful in writing macros for use in ClojureScript.
