### PR TITLE
remove RET keybinding

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -108,7 +108,6 @@ Clojure to load that file."
     (define-key map "\C-c\C-l" 'clojure-load-file)
     (define-key map "\C-c\C-r" 'lisp-eval-region)
     (define-key map "\C-c\C-z" 'clojure-display-inferior-lisp-buffer)
-    (define-key map (kbd "RET") 'reindent-then-newline-and-indent)
     (define-key map (kbd "C-c t") 'clojure-jump-to-test)
     (define-key map (kbd "C-c M-q") 'clojure-fill-docstring)
     map)


### PR DESCRIPTION
From [23.2.1, GNU Emacs Lisp Reference Manual edition 3.1](http://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Major-Mode-Conventions):

> Major modes for editing text should not define <RET> to do anything other than insert a newline.

fixes #29
