### PR TITLE
Use paredit-mode-hook to enable electric '{' and '}'

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -191,8 +191,8 @@ if that value is non-nil."
   (add-hook 'paredit-mode-hook
             (lambda ()
               (when (>= paredit-version 21)
-                (define-key paredit-mode-map "{" 'paredit-open-curly)
-                (define-key paredit-mode-map "}" 'paredit-close-curly))))
+                (define-key clojure-mode-map "{" 'paredit-open-curly)
+                (define-key clojure-mode-map "}" 'paredit-close-curly))))
 
   (run-mode-hooks 'clojure-mode-hook)
   (run-hooks 'prog-mode-hook))


### PR DESCRIPTION
This allows modes that derive from `clojure-mode` to also have this behavior.
