### PR TITLE
Explicitly require tramp and inf-lisp

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1137,7 +1137,8 @@ The arguments are dir, hostname, and port.  The return value should be an `alist
 
     (when (and (functionp 'slime-disconnect)
                (slime-current-connection)
-               (and (interactive-p) (y-or-n-p "Close old connections first? ")))
+               (and (called-interactively-p 'any)
+                    (y-or-n-p "Close old connections first? ")))
       (slime-disconnect)
       (clojure-kill-swank-buffer swank-buffer-name))
     (clojure-jack-in-start-process connection-name swank-buffer-name


### PR DESCRIPTION
This fixes the following compilation warnings:

```
clojure-mode.el:1249:1:Warning: the following functions are not known to be defined:
    inferior-lisp-proc, switch-to-lisp, tramp-dissect-file-name,
    tramp-file-name-localname, tramp-make-tramp-file-name,
    tramp-file-name-method, tramp-file-name-user,
    tramp-file-name-host

clojure-mode.el:1250:1:Warning: the following functions are not known to be defined:
    inferior-lisp-proc, switch-to-lisp
```
