### PR TITLE
Update clojure-test-mode for leiningen test structure.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -109,8 +109,8 @@ Clojure to load that file."
     (define-key map "\C-c\C-e" 'lisp-eval-last-sexp)
     (define-key map "\C-c\C-l" 'clojure-load-file)
     (define-key map "\C-c\C-r" 'lisp-eval-region)
+    (define-key map (kbd "C-c C-s") 'clojure-jump-between-tests-and-code)
     (define-key map "\C-c\C-z" 'clojure-display-inferior-lisp-buffer)
-    (define-key map (kbd "C-c t") 'clojure-jump-to-test)
     (define-key map (kbd "C-c M-q") 'clojure-fill-docstring)
     map)
   "Keymap for Clojure mode. Inherits from `lisp-mode-shared-map'.")
@@ -1172,7 +1172,7 @@ The arguments are dir, hostname, and port.  The return value should be an `alist
 
 ;; Test navigation:
 (defun clojure-in-tests-p ()
-  (or (string-match-p "test\." (clojure-find-ns))
+  (or (string-match-p "-test$" (clojure-find-ns))
       (string-match-p "/test" (buffer-file-name))))
 
 (defun clojure-underscores-for-hyphens (namespace)
@@ -1183,7 +1183,8 @@ The arguments are dir, hostname, and port.  The return value should be an `alist
          (segments (split-string namespace "\\."))
          (before (subseq segments 0 clojure-test-ns-segment-position))
          (after (subseq segments clojure-test-ns-segment-position))
-         (test-segments (append before (list "test") after)))
+	 (newfile (format "%s_test" (car after)))
+         (test-segments (append before (list newfile))))
     (mapconcat 'identity test-segments "/")))
 
 (defun clojure-jump-to-test ()

--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -325,9 +325,10 @@ Retuns the problem overlay if such a position is found, otherwise nil."
           (if (> 0 clojure-test-ns-segment-position)
               (1- (+ (length segments) clojure-test-ns-segment-position))
             clojure-test-ns-segment-position))
-         (before (subseq segments 0 test-position))
-         (after (subseq segments (1+ test-position)))
-         (impl-segments (append before after)))
+         (before (subseq segments 0 clojure-test-ns-segment-position))
+         (after (subseq segments clojure-test-ns-segment-position))
+	 (newfile (replace-regexp-in-string "_test$" "" (car after)))
+         (impl-segments (append before (list newfile))))
     (mapconcat 'identity impl-segments "/")))
 
 ;; Commands
@@ -343,7 +344,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
     (clojure-test-clear
      (lambda (&rest args)
        ;; clojure-test-eval will wrap in with-out-str
-       (clojure-test-eval (format "(clojure.core/load-file %s)"
+       (clojure-test-eval (format "(clojure.core/load-file \"%s\")"
                                   (expand-file-name (buffer-file-name)))
                          (lambda (&rest args)
                            (clojure-test-eval "(binding [clojure.test/report
@@ -428,7 +429,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
     (define-key map (kbd "C-c C-'") 'clojure-test-show-result)
     (define-key map (kbd "C-c '")   'clojure-test-show-result)
     (define-key map (kbd "C-c k")   'clojure-test-clear)
-    (define-key map (kbd "C-c t")   'clojure-test-jump-to-implementation)
+    (define-key map (kbd "C-c C-s") 'clojure-jump-between-tests-and-code)
     (define-key map (kbd "M-p")     'clojure-test-previous-problem)
     (define-key map (kbd "M-n")     'clojure-test-next-problem)
     map)


### PR DESCRIPTION
Changed clojure-test-mode test structure to what leiningen is using atm.
Changed the keybinding to switch between test and implmentation to "C-c C-s".

Hi there,
as is started programming clojure three days ago (btw. my first lisp) i noticed that there are some differences between where leiningen expects test and where clojure-test-mode expect tests.
I saw the issues on the official repository and tried to fix them as a first exercise for lisp.
As i am fairly new to lisp, the code must be really bad. (Maybe introduced bugs?) Also i didn't updated the documentation for the new test paths.
I just want some feedback if these issues should be fixed at all and if so, what i have to do additionally, so that my code gets accepted.

Regards
