### PR TITLE
clojure-jump-to-test should use the same dir/name structure as Lein.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1201,9 +1201,9 @@ The arguments are dir, hostname, and port.  The return value should be an `alist
          (segments (split-string namespace "\\."))
          (before (subseq segments 0 clojure-test-ns-segment-position))
          (after (subseq segments clojure-test-ns-segment-position))
-	 (newfile (format "%s_test" (car after)))
+	 (newfile (car after))
          (test-segments (append before (list newfile))))
-    (mapconcat 'identity test-segments "/")))
+    (mapconcat 'identity test-segments "/test/")))
 
 (defun clojure-jump-to-test ()
   "Jump from implementation file to test."


### PR DESCRIPTION
Eg. project/test/namespace/test/core
