### PR TITLE
Fixed 'clojure-jump-between-tests-and-code' when the namespace is

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1198,14 +1198,13 @@ The arguments are dir, hostname, and port.  The return value should be an `alist
 
 (defun clojure-test-for (namespace)
   (let* ((namespace (clojure-underscores-for-hyphens namespace))
-         (segments (split-string namespace "\\."))
-         (test-segments (append (list (first segments) "test") (rest segments))))
-    (mapconcat 'identity test-segments "/")))
+         (segments (split-string namespace "\\.")))
+    (mapconcat 'identity segments "/")))
 
 (defun clojure-jump-to-test ()
   "Jump from implementation file to test."
   (interactive)
-  (find-file (format "%stest/%s.clj"
+  (find-file (format "%stest/%s_test.clj"
                      (file-name-as-directory
                       (locate-dominating-file buffer-file-name "src/"))
                      (clojure-test-for (clojure-find-ns)))))

--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -326,7 +326,9 @@ Retuns the problem overlay if such a position is found, otherwise nil."
 (defun clojure-test-implementation-for (namespace)
   (let* ((namespace (clojure-underscores-for-hyphens namespace))
          (segments (split-string namespace "\\."))
-         (impl-segments (cons (first segments) (rest (rest segments)))))
+         (namespace-end (split-string (car (last segments)) "_"))
+         (namespace-end (mapconcat 'identity (butlast namespace-end 1) "_"))
+         (impl-segments (append (butlast segments 1) (list namespace-end))))
     (mapconcat 'identity impl-segments "/")))
 
 ;; Commands


### PR DESCRIPTION
several levels deep.
