### PR TITLE
Fix slime hook

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -754,7 +754,7 @@ check for contextual indenting."
 (put 'extend-type 'clojure-backtracking-indent '(4 (2)))
 (put 'extend-protocol 'clojure-backtracking-indent '(4 (2)))
 
-(defun put-clojure-indent (sym indent)
+(defun put-clojure-indent (sym indent &optional packages)
   (put sym 'clojure-indent-function indent))
 
 (defmacro define-clojure-indent (&rest kvs)


### PR DESCRIPTION
When I start slime, I've this error:
Debugger entered--Lisp error: (wrong-number-of-arguments (lambda (sym indent) (put sym (quote clojure-indent-function) indent)) 3)

Because slime calls its hook with 3 arguments and not 2.

Signed-off-by: Julien Danjou julien@danjou.info
