### PR TITLE
Bind clojure-jump-between-tests-and-code to C-c C-t.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once you have a repl session active, you can run the tests in the
 current buffer with `C-c C-,`. Failing tests and errors will be
 highlighted using overlays. To clear the overlays, use `C-c k`.
 
-You can jump between implementation and test files with `C-c t` if
+You can jump between implementation and test files with `C-c C-t` if
 your project is laid out in a way that clojure-test-mode expects. Your
 project root should have a `src/` directory containing files that
 correspond to their namespace. It should also have a `test/` directory

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -358,7 +358,7 @@ Clojure to load that file."
     (define-key map "\C-c\C-e" 'lisp-eval-last-sexp)
     (define-key map "\C-c\C-l" 'clojure-load-file)
     (define-key map "\C-c\C-r" 'lisp-eval-region)
-    (define-key map (kbd "C-c C-s") 'clojure-jump-between-tests-and-code)
+    (define-key map (kbd "C-c C-t") 'clojure-jump-between-tests-and-code)
     (define-key map "\C-c\C-z" 'clojure-display-inferior-lisp-buffer)
     (define-key map (kbd "C-c M-q") 'clojure-fill-docstring)
     map)

--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -430,7 +430,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
     (define-key map (kbd "C-c C-'") 'clojure-test-show-result)
     (define-key map (kbd "C-c '")   'clojure-test-show-result)
     (define-key map (kbd "C-c k")   'clojure-test-clear)
-    (define-key map (kbd "C-c C-s") 'clojure-jump-between-tests-and-code)
+    (define-key map (kbd "C-c C-t") 'clojure-jump-between-tests-and-code)
     (define-key map (kbd "M-p")     'clojure-test-previous-problem)
     (define-key map (kbd "M-n")     'clojure-test-next-problem)
     map)


### PR DESCRIPTION
Useful since C-c C-s gets shadowed by nrepl minor mode.
