### PR TITLE
Use semantically correct font faces for special forms and core functions

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -155,7 +155,7 @@
             "gen-class" "gen-and-load-class" "gen-and-save-class"
             "handler-case" "handle") t)
          "\\>")
-       1 font-lock-builtin-face)
+       1 font-lock-keyword-face)
       ;; Built-ins
       (,(concat
          "(\\(?:clojure.core/\\)?"
@@ -263,7 +263,7 @@
         "with-meta" "with-open" "with-out-str" "with-precision" "xml-seq" "zipmap"
         ) t)
          "\\>")
-       1 font-lock-variable-name-face)
+       1 font-lock-builtin-face)
       ;;Other namespaces in clojure.jar
       (,(concat
          "(\\(?:\.*/\\)?"


### PR DESCRIPTION
Traditionally all Emacs major modes for Lisp languages have used `font-lock-keyword-face` for special forms instead of `font-lock-builtin-face`, so it would make a lot of sense if clojure-mode used it as well. On a related note non Lisp mode uses special highlighting for core library functions and macros - I guess because it's against the spirit of considering all abstractions equal. Currently this highlighting in clojure-mode is done via `font-lock-variable-face`, but I think it's better to use `font-lock-builtin-face` for obvious reasons. I guess it would be a good idea to make this highlighting opt-outable and I plan to submit another PR on the subject.
