### PR TITLE
More robust file extension regex

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1262,7 +1262,7 @@ The arguments are dir, hostname, and port.  The return value should be an `alist
   (add-hook 'slime-connected-hook 'clojure-enable-slime-on-existing-buffers)
   (add-hook 'slime-indentation-update-hooks 'put-clojure-indent)
 
-  (add-to-list 'auto-mode-alist '("\\.clj$" . clojure-mode))
+  (add-to-list 'auto-mode-alist '("\\.clj\\'" . clojure-mode))
   (add-to-list 'interpreter-mode-alist '("jark" . clojure-mode))
   (add-to-list 'interpreter-mode-alist '("cake" . clojure-mode)))
 

--- a/clojurescript-mode.el
+++ b/clojurescript-mode.el
@@ -97,7 +97,7 @@
 (put-clojure-indent 'this-as 'defun)
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.cljs$" . clojurescript-mode))
+(add-to-list 'auto-mode-alist '("\\.cljs\\'" . clojurescript-mode))
 
 (provide 'clojurescript-mode)
 ;;; clojurescript-mode.el ends here


### PR DESCRIPTION
`\'` is a more robust way to check for the end of string in Emacs Lisp. Details can be found here http://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Special.html#Regexp-Special and here http://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Backslash.html#Regexp-Backslash 

Most idiomatic Emacs Lisp code uses `\'` instead of `$`.
