### PR TITLE
Added a menu for clojure-mode

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -348,7 +348,6 @@ Clojure to load that file."
     ["Fill Docstring" clojure-fill-docstring]
     ["Jump Between Test and Code" clojure-jump-between-tests-and-code]))
 
-
 (defvar clojure-mode-syntax-table
   (let ((table (copy-syntax-table emacs-lisp-mode-syntax-table)))
     (modify-syntax-entry ?~ "'   " table)


### PR DESCRIPTION
While most experienced Emacs users don't generally use menus they are quite useful for new users. Just about every major mode defines a menu, so I think `clojure-mode` should be not exception.
