### PR TITLE
Running single test after test-rename doesn't work as expected

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -334,6 +334,7 @@ Retuns the problem overlay if such a position is found, otherwise nil."
   "Run the test at point."
   (interactive)
   (save-some-buffers nil (lambda () (equal major-mode 'clojure-mode)))
+  (imenu--make-index-alist)
   (clojure-test-clear)
   (let* ((f (which-function))
          (test-name (if (listp f) (first f) f)))


### PR DESCRIPTION
The reproducer is:
1. run single test
2. rename the test
3. run single test again

Result: test with old name is run.

The code forces refreshing imenu index.

I'm not sure imenu is the only possiblity to get current function, so others didn't have to run into this issue. If so, the refresh should be conditional.
