### PR TITLE
Remove misplaced (interactive) call

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -385,7 +385,6 @@ or to switch back to an existing one.
 
 Entry to this mode calls the value of `clojure-mode-hook'
 if that value is non-nil."
-  (interactive)
   (use-local-map clojure-mode-map)
   (set (make-local-variable 'imenu-create-index-function)
        (lambda ()


### PR DESCRIPTION
The removed line produced this compiler warning:

```
In clojure-mode:
clojure-mode.el:388:4:Warning: misplaced interactive spec: `(interactive)'
```
