### PR TITLE
Make configurable the behavior of jump-to-test/impl

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -979,17 +979,22 @@ returned."
   (replace-regexp-in-string "-" "_" namespace))
 
 (defun clojure-test-for (namespace)
+  "Returns the path of the test file for the given namespace."
   (let* ((namespace (clojure-underscores-for-hyphens namespace))
          (segments (split-string namespace "\\.")))
-    (mapconcat 'identity segments "/")))
+    (format "%stest/%s_test.clj"
+            (file-name-as-directory
+             (locate-dominating-file buffer-file-name "src/"))
+            (mapconcat 'identity segments "/"))))
+
+(defvar clojure-test-for-fn 'clojure-test-for
+  "Var pointing to the function that will return the full path of the
+Clojure test file for the given namespace.")
 
 (defun clojure-jump-to-test ()
   "Jump from implementation file to test."
   (interactive)
-  (find-file (format "%stest/%s_test.clj"
-                     (file-name-as-directory
-                      (locate-dominating-file buffer-file-name "src/"))
-                     (clojure-test-for (clojure-find-ns)))))
+  (find-file (funcall clojure-test-for-fn (clojure-find-ns))))
 
 (defun clojure-jump-between-tests-and-code ()
   (interactive)

--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -305,12 +305,19 @@ Retuns the problem overlay if such a position is found, otherwise nil."
 ;; File navigation
 
 (defun clojure-test-implementation-for (namespace)
+  "Returns the path of the src file for the given test namespace."
   (let* ((namespace (clojure-underscores-for-hyphens namespace))
          (segments (split-string namespace "\\."))
          (namespace-end (split-string (car (last segments)) "_"))
          (namespace-end (mapconcat 'identity (butlast namespace-end 1) "_"))
          (impl-segments (append (butlast segments 1) (list namespace-end))))
-    (mapconcat 'identity impl-segments "/")))
+    (format "%s/src/%s.clj"
+            (locate-dominating-file buffer-file-name "src/")
+            (mapconcat 'identity impl-segments "/"))))
+
+(defvar clojure-test-implementation-for-fn 'clojure-test-implementation-for
+  "Var pointing to the function that will return the full path of the
+Clojure src file for the given test namespace.")
 
 ;; Commands
 
@@ -397,9 +404,8 @@ Retuns the problem overlay if such a position is found, otherwise nil."
 (defun clojure-test-jump-to-implementation ()
   "Jump from test file to implementation."
   (interactive)
-  (find-file (format "%s/src/%s.clj"
-                     (locate-dominating-file buffer-file-name "src/")
-                     (clojure-test-implementation-for (clojure-find-package)))))
+  (find-file (funcall clojure-test-implementation-for-fn
+                      (clojure-find-package))))
 
 (defvar clojure-test-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
This is achieved by making the functions clojure-test-for and
clojure-test-implementation-for return the full path of the test or
src file. Next clojure-jump-to-test and
clojure-test-jump-to-implementation simply calls these functions
through a defvar to get the path. That var can be changed by users who
want a different implementation.

The added defvars are:
clojure-test-for-fn - defaults to clojure-test-for
clojure-test-implementation-for-fn - defaults to clojure-test-implementation-for

The existing behavior of where test files are created was left
unchanged.

An example of overriding the defaults to get the old behavior of tests 
and impls such as:

```
src/project/foo/bar => (ns project.foo.bar)
test/project/test/foo/bar => (ns project.test.foo.bar)
```

``` lisp
(defun my-clojure-test-for (namespace)
  (let* ((namespace (clojure-underscores-for-hyphens namespace))
         (segments (split-string namespace "\\."))
         (before (subseq segments 0 1))
         (after (subseq segments 1))
         (test-segments (append before (list "test") after)))
    (format "%stest/%s.clj"
            (locate-dominating-file buffer-file-name "src/")
            (mapconcat 'identity test-segments "/"))))

(defun my-clojure-test-implementation-for (namespace)
  (let* ((namespace (clojure-underscores-for-hyphens namespace))
         (segments (split-string namespace "\\."))
         (before (subseq segments 0 1))
         (after (subseq segments 2))
         (impl-segments (append before after)))
    (format "%s/src/%s.clj"
            (locate-dominating-file buffer-file-name "src/")
            (mapconcat 'identity impl-segments "/"))))

(setq clojure-test-for-fn 'my-clojure-test-for)
(setq clojure-test-implementation-for-fn 
      'my-clojure-test-implementation-for)
```
