### PR TITLE
Associate .dtm and .edn files with Clojure mode.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1003,6 +1003,8 @@ returned."
   (put 'clojure-mode-load-command 'safe-local-variable 'stringp)
 
   (add-to-list 'auto-mode-alist '("\\.clj\\'" . clojure-mode))
+  (add-to-list 'auto-mode-alist '("\\.dtm\\'" . clojure-mode))
+  (add-to-list 'auto-mode-alist '("\\.edn\\'" . clojure-mode))
   (add-to-list 'interpreter-mode-alist '("jark" . clojure-mode))
   (add-to-list 'interpreter-mode-alist '("cake" . clojure-mode)))
 


### PR DESCRIPTION
`.dtm` is typically used for Datomic schemas and `.edn` is the
extension of Extensible Data Notation(EDN) files. Both are
essentially Clojure code.

I could have used a single regexp for clj, edn and dtm, but I feel the code looks cleaner as is.
