### PR TITLE
Bugfix: Resolve all symbolic links when finding expected ns

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -939,7 +939,7 @@ returned."
   (let* ((project-dir (file-truename
                        (locate-dominating-file default-directory
                                                "project.clj")))
-         (relative (substring (buffer-file-name) (length project-dir) -4)))
+         (relative (substring (file-truename (buffer-file-name)) (length project-dir) -4)))
     (replace-regexp-in-string
      "_" "-" (mapconcat 'identity (cdr (split-string relative "/")) "."))))
 


### PR DESCRIPTION
- symlinks are removed from the project-dir
- they need also be removed from the buffer-file-name
