### PR TITLE
clojure-insert-ns-form-here -- new convienience function

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -947,7 +947,7 @@ returned."
     (replace-regexp-in-string
      "_" "-" (mapconcat 'identity (cdr (split-string relative "/")) "."))))
 
-(defun clojure-insert-ns-form-here ()
+(defun clojure-insert-ns-form-at-point ()
   "Insert a namespace form at point"
   (interactive)
   (insert (format "(ns %s)" (clojure-expected-ns))))


### PR DESCRIPTION
This adds a new command, clojure-insert-ns-form-here, which adds a
ns form at the current position, rather than at the beginning of the file.
This is particularly useful when there is a boilerplate header. The
clojure-insert-ns-form function has been refactored, but has unchanged
functionality.
