### PR TITLE
Fixes indentation of functions with 'with-' in their name.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -646,7 +646,7 @@ This function also returns nil meaning don't specify the indentation."
               ((or (eq method 'defun)
                    (and (null method)
                         (> (length function) 3)
-                        (string-match "\\`\\(?:\\S +/\\)?def\\|with-"
+                        (string-match "\\`\\(?:\\S +/\\)?\\(def\\|with-\\)"
                                       function)))
                (lisp-indent-defform state indent-point))
 


### PR DESCRIPTION
clojure-indent-function was incorrectly indenting as a def form an
invocation of a function with 'with-' anywhere in its name.

For example, it was doing:

``` clojure
(with-filling
  (sandwich :peanutbutter :jelly))

(sandwich-with-filling :peanutbutter
  :jelly)
```

Instead of:

``` clojure
(with-filling
  (sandwich :peanutbutter :jelly))

(sandwich-with-filling :peanutbutter
                       :jelly)
```

Now it does the latter.
