### PR TITLE
Implement highlighting of grouping constructs in Clojure regular expressions

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -547,7 +547,7 @@ in regular expression."
 	(when (and (or (and (listp face)
 			    (memq 'font-lock-string-face face))
 		       (eq 'font-lock-string-face face))
-		   (ignore-errors (clojure-string-start t)))
+		   (clojure-string-start t))
 	  (throw 'found t))))))
 
 (defun clojure-find-block-comment-start (limit)


### PR DESCRIPTION
The changes included in this pull request implement highlighting of grouping constructs in Clojure regular expressions similar to how grouping constructs are highlighted in Emacs Lisp  strings.
