### PR TITLE
Indent clojure.test/are like other binding forms

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -797,6 +797,7 @@ use (put-clojure-indent 'some-symbol 'defun)."
   ;; clojure.test
   (testing 1)
   (deftest 'defun)
+  (are 1)
   (use-fixtures 'defun))
 
 


### PR DESCRIPTION
``` clojure
; Without patch:

(are [foo]
     bar
     baz)

; With patch:

(are [foo]
  bar
  baz)
```
