### PR TITLE
Makes clojure-test-maybe-enable more discriminating.

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -536,12 +536,10 @@ Clojure src file for the given test namespace.")
 ;;;###autoload
 (progn
   (defun clojure-test-maybe-enable ()
-    "Enable clojure-test-mode if the current buffer contains a namespace
-with a \"test.\" bit on it."
-    (let ((res (clojure-find-clojure-test)))
-      (when (and res (string-match "clojure\\.test" res))
-        (save-window-excursion
-          (clojure-test-mode t)))))
+    "Enable clojure-test-mode if the current buffer contains a \"clojure.test\" bit in it."
+    (when (clojure-find-clojure-test)
+      (save-window-excursion
+        (clojure-test-mode t))))
 
   (add-hook 'clojure-mode-hook 'clojure-test-maybe-enable))
 


### PR DESCRIPTION
It will only enable clojure-test-mode if it finds clojure.test somewhere in the
file.  This will prevent clojure-test-mode getting enabled for namespaces with
'test.' in their name that are for other testing frameworks.

It will also allow clojure-test-mode to co-exist with emacs modes for those
other frameworks.  (I thinking specifically of conjecture-mode.)
