### PR TITLE
clojure-find-clojure-test should be autoloaded

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -525,6 +525,7 @@ Clojure src file for the given test namespace.")
 (defconst clojure-test-regex
   (rx "clojure.test"))
 
+;;;###autoload
 (defun clojure-find-clojure-test ()
   (let ((regexp clojure-test-regex))
     (save-restriction


### PR DESCRIPTION
Without this change I'm getting `File mode specification error: (void-function clojure-find-clojure-test)`.
