### PR TITLE
Make clojure-find-ns handle ns declarations with leading whitespace

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -975,6 +975,7 @@ returned."
 
 (defconst clojure-namespace-name-regex
   (rx line-start
+      (zero-or-more whitespace)
       "("
       (zero-or-one (group (regexp "clojure.core/")))
       (zero-or-one (submatch "in-"))


### PR DESCRIPTION
`clojure-find-ns` does not currently find a namespace if the source file contains leading spaces before the `ns` form:

``` clojure
     (ns blahonga)
; ^- whitespace, oh no!

```

Compiling this file, and then trying to switch to the namespace will fail.

This pull request attempts to solve this (very minor but subtle) issue by extending `clojure-namespace-name-regex` to allow zero or more whitespace characters before the ns form
