### PR TITLE
Correctly fill the docstrings

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -956,17 +956,19 @@ returned."
   (let ((old-point (point)))
     (save-restriction
       (save-excursion
-        (let* ((string-region (clojure-docstring-start+end-points))
-               (string-start (1+ (car string-region)))
+        (let* ((clojure-fill-column fill-column)
+               (string-region (clojure-docstring-start+end-points))
+               (string-start (car string-region))
                (string-end (cdr string-region))
-               (string (buffer-substring-no-properties (1+ (car string-region))
-                                                       (cdr string-region))))
+               (string (buffer-substring-no-properties string-start
+                                                       string-end)))
           (delete-region string-start string-end)
           (insert
            (with-temp-buffer
              (insert string)
              (let ((left-margin 2))
                (delete-trailing-whitespace)
+               (setq fill-column clojure-fill-column)
                (fill-region (point-min) (point-max))
                (buffer-substring-no-properties (+ 2 (point-min)) (point-max))))))))
     (goto-char old-point)))


### PR DESCRIPTION
First, use the fill-column setting of the edited file and not the global one.

Second, fill the first line correctly. Previously the first line of
docstring could be filled to fill-column+1 characters, because the
initial " was dropped out of the fill calculations.

Example of the latter - set fill-column to 70 and clojure-fill-docstring inside the docstring.

```
(defn foo
  "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo quux bar")

;; This is what you should get:
(defn foo
  "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo
  quux bar")

;; This is what you got before this patch. There are 71 chars on the first docstring line.
(defn foo
  "foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo quux
  bar")
```

I'm just a beginner with Emacs Lisp, so hopefully I didn't do anything silly.
