### PR TITLE
Configurable docstring margin

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -862,7 +862,7 @@ returned."
   (forward-char)
   (set-mark (clojure-string-end)))
 
-(defvar clojure-docstring-indent-level 3)
+(defvar clojure-docstring-indent-level 2)
 
 (defun clojure-fill-docstring (&optional argument)
   "Fill the definition that the point is on appropriate for Clojure.


### PR DESCRIPTION
Current implementation indents by 2, but I would argue most clojure projects indent to 3 (aligning subsequent lines with the first letter of the docstring rather than the quote mark). This pull request makes it configurable defaulting to 3.
