### PR TITLE
fix remaining . at end of namespace for cljs

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1064,7 +1064,9 @@ remain indented by four spaces after refilling."
   (let* ((project-dir (file-truename
                        (locate-dominating-file default-directory
                                                "project.clj")))
-         (relative (substring (file-truename (buffer-file-name)) (length project-dir) -4)))
+         (relative (substring (file-truename (buffer-file-name))
+                              (length project-dir)
+                              (- (length (file-name-extension (buffer-file-name) t))))))
     (replace-regexp-in-string
      "_" "-" (mapconcat 'identity (cdr (split-string relative "/")) "."))))
 


### PR DESCRIPTION
When using clojure-mode for clojurescript there was a remaining . at
then end of the string returned by `clojure-expected-ns`. This patch
removes the hardcoded file-extension size in favour of calculating the
size based on the buffer-file-name.
