### PR TITLE
add .cljx to auto-mode-alist

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1195,6 +1195,7 @@ word test in it and whether the file lives under the test/ directory."
 (progn
   (add-to-list 'auto-mode-alist '("\\.clj\\'" . clojure-mode))
   (add-to-list 'auto-mode-alist '("\\.cljs\\'" . clojure-mode))
+  (add-to-list 'auto-mode-alist '("\\.cljx\\'" . clojure-mode))
   (add-to-list 'auto-mode-alist '("\\.dtm\\'" . clojure-mode))
   (add-to-list 'auto-mode-alist '("\\.edn\\'" . clojure-mode))
   (add-to-list 'interpreter-mode-alist '("jark" . clojure-mode))


### PR DESCRIPTION
Cljx is a Leiningen plugin allowing one to write portable Clojure/ClojureScript code using "feature expression" annotations:

https://github.com/lynaghk/cljx

Such code is held in `.cljx` files, which — aside from those annotations — are Clojure files, which deserve proper clojure-mode handling.
