### PR TITLE
Rename nrepl-emit-interactive-output to cider

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -455,7 +455,7 @@ Clojure src file for the given test namespace.")
                          (clojure-find-ns))))
     (nrepl-send-string-sync command)))
 
-(defun clojure-test-clear (&optional callback)
+(defun clojure-test-clear ()
   "Remove overlays and clear stored results."
   (interactive)
   (remove-overlays)


### PR DESCRIPTION
clojure-test-mode was not reporting test results, which appears to be due to calling methods that were renamed into the cider namespace.

Also removes an unused parameter on clojure-test-clear.
