### PR TITLE
set open-paren-in-column-0-is-defun-start to nil buffer-local in clojure-mode, fixes gh-183, fixes gh-140

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -496,6 +496,7 @@ if that value is non-nil."
   (setq-local parse-sexp-ignore-comments t)
 
   (clojure-mode-font-lock-setup)
+  (setq-local open-paren-in-column-0-is-defun-start nil)
   (add-hook 'paredit-mode-hook
             (lambda ()
               (when (>= paredit-version 21)


### PR DESCRIPTION
/ht to @tsdh for gently prodding with the hints about buffer-local settings, etc. Turns out clojure-mode is already using `setq-local` all over the place.. Should stop walking on eggshells with the elisp, I guess. :-)
