### PR TITLE
Fix `clojure-indent-function` not handling overrides correctly when `clojure-defun-style-default-indent` is enabled.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -772,7 +772,8 @@ This function also returns nil meaning don't specify the indentation."
               ((or (eq method 'defun)
                    (and clojure-defun-style-default-indent
                         ;; largely to preserve useful alignment of :require, etc in ns
-                        (not (string-match "^:" function)))
+                        (not (string-match "^:" function))
+                        (not method))
                    (and (null method)
                         (> (length function) 3)
                         (string-match "\\`\\(?:\\S +/\\)?\\(def\\|with-\\)"


### PR DESCRIPTION
From the clojure-mode README:

> This causes "defun" indentation rules to apply by default for any parenthesized 
> form **that does not otherwise have an indentation rule set on clojure-indent-function**.

This PR adds an additional check to see if that override is present.

Example:

```
;; elisp
(setq clojure-defun-style-default-indent t)

;; clojure -- | = carat
(foo bar
    |baz)

;; emacs
M-x paredit-reindent-function RET

;; clojure
(foo bar
  |baz)

;; elisp
(define-clojure-indent
  (foo 0))

;; clojure
(foo bar
  |baz)

;; emacs
M-x paredit-reindent-function RET

;; clojure
(foo bar
    |baz)

```
