### PR TITLE
catch error in clojure-test-mode to prevent user-visible error

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -155,7 +155,9 @@
 ;; Support Functions
 
 (defun clojure-test-nrepl-connected-p ()
-  (nrepl-current-connection-buffer))
+  (condition-case nil
+      (nrepl-current-connection-buffer)
+    (error nil)))
 
 (defun clojure-test-make-handler (callback)
   (lexical-let ((buffer (current-buffer))


### PR DESCRIPTION
The `nrepl-current-connection-buffer` in current CIDER now throws an
error when there is no connection, so this breaks initialization of
`clojure-test-mode`, especially during startup.

This small change fixes this problem
