### PR TITLE
support highlighting when def... includes hyphen/s

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -100,7 +100,7 @@
        (1 font-lock-keyword-face)
        (2 font-lock-function-name-face nil t))
 
-      (,(concat "(\\(\\(?:[a-z\.-]+/\\)?def\[a-z\]*-?\\)"
+      (,(concat "(\\(\\(?:[a-z\.-]+/\\)?def\[a-z\-\]*-?\\)"
                 ;; Function declarations.
                 "\\>"
                 ;; Any whitespace


### PR DESCRIPTION
Sometimes I have variants of `def...` macros I've written, and their names will include hyphens. At present, this means that `(def... var-name ...)` expressions for those hyphenated `def...` names don't benefit from the highlighting they would have if they didn't include hyphens. This simple patch is an attempt to remedy that situation, and it seems to work fine, but I will admit that I'm not 100% certain that additional changes don't need to be made elsewhere in `clojure-mode.el`.
