### PR TITLE
clojure-test-mode not running tests because of missing cider-emit-interactive-output

### DIFF
--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -166,9 +166,9 @@
                                  (lambda (buffer value)
                                    (funcall callback buffer value))
                                  (lambda (buffer value)
-                                   (cider-emit-interactive-output value))
+                                   (cider-repl-emit-interactive-output value))
                                  (lambda (buffer err)
-                                   (cider-emit-interactive-output err))
+                                   (cider-repl-emit-interactive-output err))
                                  '())))
 
 (defun clojure-test-eval (string &optional handler)


### PR DESCRIPTION
I don't see a definition of cider-emit-interactive-output, only
cider-**repl**-emit-interactive-output. That seems to work, so...

Maybe this is related to #184? I tried looking in the history of clojure-test-mode.el and cider and can't find cider-emit-interactive-output.
