### PR TITLE
Customizable jump between test-/impl ns

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -365,6 +365,23 @@ in :db/id[:db.part/user]"
           (and (listp value)
                (every 'characterp value))))
 
+(defcustom clojure-test-dir-prefix "test"
+  "Used by clojure-test-for-fn to resolve a test namespace for the current
+buffer.  This is the path component between the project root and the test.
+Leiningen puts sources and tests in <root>/src and <root>/test respectively.
+Omit leading and trailing slashes!"
+  :type 'string
+  :group 'clojure
+  :safe 'stringp)
+
+(defcustom clojure-src-dir-prefix "src"
+  "The folder that contains the source namespaces. Used by
+clojure-test-implementation-for to resolve a test namespace
+to its corresponding source. Omit leading and trailing slashes!"
+  :type 'string
+  :group 'clojure
+  :safe 'stringp)
+
 (defvar clojure-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map lisp-mode-shared-map)
@@ -1173,9 +1190,10 @@ word test in it and whether the file lives under the test/ directory."
   "Return the path of the test file for the given NAMESPACE."
   (let* ((namespace (clojure-underscores-for-hyphens namespace))
          (segments (split-string namespace "\\.")))
-    (format "%stest/%s_test.clj"
+    (format "%s/%s/%s_test.clj"
             (file-name-as-directory
              (locate-dominating-file buffer-file-name "src/"))
+            clojure-test-dir-prefix
             (mapconcat 'identity segments "/"))))
 
 (defvar clojure-test-for-fn 'clojure-test-for

--- a/clojure-test-mode.el
+++ b/clojure-test-mode.el
@@ -328,8 +328,9 @@ Retuns the problem overlay if such a position is found, otherwise nil."
          (namespace-end (split-string (car (last segments)) "_"))
          (namespace-end (mapconcat 'identity (butlast namespace-end 1) "_"))
          (impl-segments (append (butlast segments 1) (list namespace-end))))
-    (format "%s/src/%s.clj"
+    (format "%s/%s/%s.clj"
             (locate-dominating-file buffer-file-name "src/")
+            clojure-src-dir-prefix
             (mapconcat 'identity impl-segments "/"))))
 
 (defvar clojure-test-implementation-for-fn 'clojure-test-implementation-for


### PR DESCRIPTION
Hello, 

This pull request is to address the issue of non-configurable `src` and `test` directory paths in `clojure-mode` and `clojure-test-mode`, that is, the path components used by the functions `clojure-test-for-fn` and `clojure-test-implementation-for`. These are used to resolve a source to its corresponding test ns and vice-versa.

Leiningen does support customization of clojure `src` and `test` directories in `project.clj` and thus should `clojure-mode`. 

Because I've been working on a project that was organized 'the maven way' I was lacking the functionality of configurable src and test directories in `clojure-mode` above.

Thought: Alternatively source and test directory location could be extracted from project.clj. I strongly advise against it though, because clojure-mode would then depend on Leiningen enabled projects and would not work for, e.g. mavenized projects.

Cheers,
Fabio
