### PR TITLE
Separate symbols for namespace and vars

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -407,6 +407,7 @@ in :db/id[:db.part/user]"
     (modify-syntax-entry ?\[ "(]" table)
     (modify-syntax-entry ?\] ")[" table)
     (modify-syntax-entry ?^ "'" table)
+    (modify-syntax-entry ?/ "." table)
     ;; Make hash a usual word character
     (modify-syntax-entry ?# "_ p" table)
     table))


### PR DESCRIPTION
By changing the syntax class of `?/` to `"."` (punctuation), Emacs considers the
namespace part and var part of `namespace/var` as two separate symbols.

One improvement is that you can now hippie-expand namespaces and vars
separately. Another is that you can use symbol boundaries to match
namespaces and vars in regexen, with `\\_<` and `\\_>`.

I found the punctuation class to be most fitting, since the Emacs docs say that it is "used in a programming language to separate symbols from one another."
