### PR TITLE
Adding syntax highlighting for clojure.core.typed.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -82,7 +82,8 @@
                 (regexp-opt '("defn" "defn-" "def" "defonce"
                               "defmulti" "defmethod" "defmacro"
                               "defstruct" "deftype" "defprotocol"
-                              "defrecord" "deftest" "def\\[a-z\\]"))
+                              "defrecord" "deftest" "def\\[a-z\\]"
+                              "ann"))
                 ;; Function declarations.
                 "\\)\\>"
                 ;; Any whitespace
@@ -284,6 +285,10 @@
             "leftmost" "lefts" "make-node" "next" "node"
             "path" "prev" "remove" "replace" "right"
             "rightmost" "rights" "root" "seq-zip" "up"
+            ;; clojure.core.typed
+            "ann-form" "cf" "defprotocol>" "doseq>" "dotimes>" "fn>"
+            "for>" "into-array>" "let-fn>" "loop>" "pfn>" "ref>"
+            "tc-ignore" "var>"
             ) t)
          "\\>")
        1 font-lock-builtin-face)


### PR DESCRIPTION
Since core.async is in here, I'm guessing core.typed is eligible for inclusion too. :-)
