### PR TITLE
Include the final " in clojure-fill-docstring

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1132,7 +1132,7 @@ remain indented by four spaces after refilling."
         (let* ((clojure-fill-column fill-column)
                (string-region (clojure-docstring-start+end-points))
                (string-start (car string-region))
-               (string-end (cdr string-region))
+               (string-end (1+ (cdr string-region)))
                (string (buffer-substring-no-properties string-start
                                                        string-end)))
           (delete-region string-start string-end)

--- a/test.clj
+++ b/test.clj
@@ -39,3 +39,9 @@
 Etiam commodo nulla id risus convallis pharetra. Integer dapibus, eros vitae vehicula rhoncus, nisl lorem ornare magna, eu vehicula justo nunc ac nunc. In dolor sem, vulputate eget vulputate id, euismod eu ligula. Nullam elit augue, ultrices ut pretium vel, bibendum sit amet est. Curabitur vulputate arcu vitae neque adipiscing vel commodo ante faucibus. Cras tempor placerat erat. Sed ultrices faucibus sodales. Vestibulum sollicitudin consectetur mauris, nec mollis quam accumsan ultrices. Vestibulum tincidunt libero a lectus condimentum et fermentum diam eleifend. Nam accumsan interdum neque nec aliquet. Praesent feugiat dui at est rhoncus lacinia."
   []
   (println "Hello, World!"))
+
+;; Set fill column (C-x f) to 80 characters and use fill the docstring.
+(defn return-nil
+  "This docstring is rather long-ish and needs to be wrapped at 80 characters..."
+  []
+  nil)


### PR DESCRIPTION
When filling a docstring, if the closing quote is ignored and your docstring almost fits on one line, you
end up with a line that is fill-column+1 characters long.

See `test.clj` in the diff for an example. The original version of the code does not break the line, even though it's 81 characters long.
