### PR TITLE
clojure-mode.el (clojure-docstring-fill-column): Use `fill-column' as th...

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -398,7 +398,7 @@ Otherwise check `define-clojure-indent' and `put-clojure-indent'."
   :group 'clojure
   :safe 'integerp)
 
-(defcustom clojure-docstring-fill-column 72
+(defcustom clojure-docstring-fill-column fill-column
   "Value of `fill-column' to use when filling a docstring."
   :type 'integer
   :group 'clojure


### PR DESCRIPTION
...e default value
- clojure-mode.el (clojure-docstring-fill-column): Use
  `fill-column' as the default value.
