### PR TITLE
Fixed bug with unbalanced parens in literal strings

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1075,7 +1075,7 @@ nil."
         (let ((beg (match-beginning 2)))
           (when beg
             (if regex
-                (and (char-equal ?# (char-before beg)) (1- beg))
+                (and (char-before beg) (char-equal ?# (char-before beg)) (1- beg))
               (when (not (char-equal ?# (char-before beg)))
                 beg))))))))
 


### PR DESCRIPTION
I faced a very weird behaviour where if I typed "(" and pressed enter in the REPL, the string would not be echoed, and in the _Messages_ buffer of Emacs I would get this error:

```
clojure-string-start: Wrong type argument: characterp, nil
```

This was true for both my emacs setups on 2 machines, but none of my 6 colleagues could reproduce it. I ran the elisp debugger and discovered that the character in `clojure-string-start` was nil. The fix involves the addition of a simple nil check.

Please merge :-)
