### PR TITLE
Fix auto-fill bugs

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -323,7 +323,8 @@ This only takes care of filling docstring correctly."
                                    "\\|\\s-*\\([(;:\"[]\\|`(\\|#'(\\)"))
           (paragraph-separate
            (concat paragraph-separate "\\|\\s-*\".*[,\\.[]$")))
-      (fill-paragraph justify)
+      (or (fill-comment-paragraph justify)
+          (fill-paragraph justify))
       ;; Always return `t'
       t)))
 
@@ -336,7 +337,7 @@ This only takes care of filling docstring correctly."
                              clojure-docstring-fill-column
                            fill-column))
             (fill-prefix (clojure-adaptive-fill-function)))
-        (when fill-prefix (do-auto-fill))))))
+        (do-auto-fill)))))
 
 (defun clojure-display-inferior-lisp-buffer ()
   "Display a buffer bound to `inferior-lisp-buffer'."


### PR DESCRIPTION
- clojure-mode.el (clojure-fill-paragraph): Fill comment paragraph
  correctly.
  (clojure-auto-fill-function): Auto-fill correctly in general, not
  only in docstrings.

Thanks to ska2342 for reporting this.
