### PR TITLE
@(dynamic)variable shouldn't break fontlock

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -467,8 +467,8 @@ Called by `imenu--generic-function'."
           t)
          "\\>")
        0 font-lock-builtin-face)
-      ;; Dynamic variables - *something*
-      ("\\<\\*[a-z-]*\\*\\>" 0 font-lock-variable-name-face)
+      ;; Dynamic variables - *something* or @*something*
+      ("\\<@?\\(\\*[a-z-]*\\*\\)\\>" 1 font-lock-variable-name-face)
       ;; Global constants - nil, true, false
       (,(concat
          "\\<"
@@ -492,8 +492,8 @@ Called by `imenu--generic-function'."
       ("\\(?:\\<\\|\\.\\|/\\|#?^\\)\\([A-Z][a-zA-Z0-9_]*[a-zA-Z0-9$_]+\\.?\\>\\)" 1 font-lock-type-face)
       ;; foo.bar.baz
       ("\\<^?\\([a-z][a-z0-9_-]+\\.\\([a-z][a-z0-9_-]*\\.?\\)+\\)" 1 font-lock-type-face)
-      ;; foo/ Foo/
-      ("\\<\\([a-zA-Z][a-z0-9_-]*\\)/" 1 font-lock-type-face)
+      ;; foo/ Foo/ @Foo/
+      ("\\<@?\\([a-zA-Z][a-z0-9_-]*\\)/" 1 font-lock-type-face)
       ;; fooBar
       ("\\(?:\\<\\|/\\)\\([a-z]+[A-Z]+[a-zA-Z0-9$]*\\>\\)" 1 'clojure-interop-method-face)
       ;; Highlight grouping constructs in regular expressions

--- a/test/clojure-mode-test.el
+++ b/test/clojure-mode-test.el
@@ -202,6 +202,16 @@ POS."
   (should (eq (clojure-test-face-at 1 5 "#+clj x") 'font-lock-preprocessor-face))
   (should (eq (clojure-test-face-at 1 6 "#+cljs x") 'font-lock-preprocessor-face)))
 
+(ert-deftest clojure-mode-syntax-table/refer-ns ()
+  :tags '(fontification syntax-table)
+  (should (eq (clojure-test-face-at 1 3 "foo/var") 'font-lock-type-face))
+  (should (eq (clojure-test-face-at 2 4 "@foo/var") 'font-lock-type-face)))
+
+(ert-deftest clojure-mode-syntax-table/dynamic-var ()
+  :tags '(fontification syntax-table)
+  (should (eq (clojure-test-face-at 1 10 "*some-var*") 'font-lock-variable-name-face))
+  (should (eq (clojure-test-face-at 2 11 "@*some-var*") 'font-lock-variable-name-face)))
+
 (provide 'clojure-mode-test)
 
 ;; Local Variables:


### PR DESCRIPTION
Currently `foo/some-var` will fontlock `foo`, but if this item is
something that can be dereffed and you type `@foo/some-var`, `foo` is no
longer font-locked.

Similarly: `*dynamic-var*` is font locked, but `@` breaks the regex.

In this change the `@` sign isn't font locked, but the var that follows
it is.
