### PR TITLE
Fix for that wrong indentation in multi-arity forms.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -715,10 +715,7 @@ This function also returns nil meaning don't specify the indentation."
           ;; thing on that line has to be complete sexp since we are
           ;; inside the innermost containing sexp.
           (backward-prefix-chars)
-          (if (and (eq (char-after (point)) ?\[)
-                   (eq (char-after (elt state 1)) ?\())
-              (+ (current-column) 2) ;; this is probably inside a defn
-            (current-column)))
+          (current-column))
       (let* ((function (buffer-substring (point)
                                          (progn (forward-sexp 1) (point))))
              (open-paren (elt state 1))


### PR DESCRIPTION
- Related issue: #239
- Revert commits: 7c3a604, ae5f46d
