### PR TITLE
@ symbol shouldn't be a word character

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -198,6 +198,7 @@ For example, \[ is allowed in :db/id[:db.part/user]."
     (modify-syntax-entry ?\[ "(]" table)
     (modify-syntax-entry ?\] ")[" table)
     (modify-syntax-entry ?^ "'" table)
+    (modify-syntax-entry ?@ "'" table)
     ;; Make hash a usual word character
     (modify-syntax-entry ?# "_ p" table)
     table))


### PR DESCRIPTION
Unless @ symbol is treated as a non-word character, symbols that are being dereferenced aren't returned in a usable fashion by `(symbol-at-point)`

See discussion on cider pull request https://github.com/clojure-emacs/cider/pull/887 and cider issue https://github.com/clojure-emacs/cider/issues/886 (which is really a clojure-mode issue, apparently)
