### PR TITLE
Fix broken `indent-for-tab-command' when point is 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Prevent error when calling `indent-for-tab-command` at the start of
+  the buffer at end of line.
+
 ## 4.0.1 (19/12/2014)
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -280,8 +280,9 @@ ENDP and DELIMITER."
 
 (defsubst clojure-in-docstring-p ()
   "Check whether point is in a docstring."
-  (eq (get-text-property (1- (point-at-eol)) 'face)
-      'font-lock-doc-face))
+  (unless (bobp)
+    (eq (get-text-property (1- (point-at-eol)) 'face)
+        'font-lock-doc-face)))
 
 (defsubst clojure-docstring-fill-prefix ()
   "The prefix string used by `clojure-fill-paragraph'.


### PR DESCRIPTION
* clojure-mode.el (clojure-in-docstring-p): Don't call
`(get-text-property 0)`, since it will throw.