### PR TITLE
Support prismatic schema s/def*.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -334,7 +334,7 @@ If JUSTIFY is non-nil, justify as well as fill the paragraph."
 (defun clojure-match-next-def ()
   "Scans the buffer backwards for the next \"top-level\" definition.
 Called by `imenu--generic-function'."
-  (when (re-search-backward "^(def\\sw*" nil t)
+  (when (re-search-backward "^([s/]*def\\sw*" nil t)
     (save-excursion
       (let (found?
             (start (point)))


### PR DESCRIPTION
We use schema.core/defn a lot, even more than clojure.core/defn.