### PR TITLE
Add .cljc to auto-mode-alist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Add .cljc to auto-mode-alist.
+
 ### Bugs fixed
 
 * Prevent error when calling `indent-for-tab-command` at the start of

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1074,7 +1074,7 @@ Returns a list pair, e.g. (\"defn\" \"abc\") or (\"deftest\" \"some-test\")."
 ;;;###autoload
 (progn
   (add-to-list 'auto-mode-alist
-               '("\\.\\(clj[sx]?\\|dtm\\|edn\\)\\'" . clojure-mode))
+               '("\\.\\(clj[csx]?\\|dtm\\|edn\\)\\'" . clojure-mode))
   ;; boot build scripts are Clojure source files
   (add-to-list 'auto-mode-alist '("\\`build.boot\\'" . clojure-mode)))
 


### PR DESCRIPTION
`.cljc` is the extension for source files which make use of [Reader Conditionals](https://github.com/clojure/clojure/blob/master/changes.md#12-reader-conditionals), per Clojure's upcoming `1.7.0` release.