### PR TITLE
Fix doctring indentation issue in #241

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -624,13 +624,14 @@ point) to check."
 (put 'definline 'clojure-doc-string-elt 2)
 (put 'defprotocol 'clojure-doc-string-elt 2)
 
-
 (defun clojure-indent-line ()
   "Indent current line as Clojure code."
   (if (clojure-in-docstring-p)
       (save-excursion
         (beginning-of-line)
-        (when (looking-at "^\\s-*")
+        (when (and (looking-at "^\\s-*")
+                   (<= (string-width (match-string-no-properties 0))
+                       (string-width (clojure-docstring-fill-prefix))))
           (replace-match (clojure-docstring-fill-prefix))))
     (lisp-indent-line)))
 

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -107,6 +107,32 @@ values of customisable variables."
 (->>
  |expr)")
 
+(check-indentation doc-strings-without-indent-specified
+  "
+(defn some-fn
+|\"some doc string\""
+  "
+(defn some-fn
+  |\"some doc string\"")
+
+(check-indentation doc-strings-with-correct-indent-specified
+  "
+(defn some-fn
+  |\"some doc string\""
+  "
+(defn some-fn
+  |\"some doc string\"")
+
+(check-indentation doc-strings-with-additional-indent-specified
+  "
+(defn some-fn
+  |\"some doc string
+    - some note\""
+  "
+(defn some-fn
+  |\"some doc string
+    - some note\"")
+
 (provide 'clojure-mode-indentation-test)
 
 ;; Local Variables:


### PR DESCRIPTION
Added code to only apply the prefix if the current indent level is <=
the default prefix spacing.