### PR TITLE
Fix indentation of specify and specify!

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -831,6 +831,8 @@ it from Lisp code, use (put-clojure-indent 'some-symbol 'defun)."
   (extend 1)
   (extend-protocol 1)
   (extend-type 1)
+  (specify 1)
+  (specify! 1)
 
   (try 0)
   (catch 2)


### PR DESCRIPTION
When using `specify` or `specify!`, clojure-mode currently fails with:

    clojure-indent-function: Wrong type argument: number-or-marker-p, (2)

This seems to be because those functions have a clojure-backtracking-indent without an associated clojure-indent defined, as is the case with `extend-type` and `extend-protocol`, which have the same indentation scheme.

This PR fixes the issue.