### PR TITLE
[Fix #295] clojure-in-docstring-p not using point

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -275,9 +275,7 @@ ENDP and DELIMITER."
 
 (defsubst clojure-in-docstring-p ()
   "Check whether point is in a docstring."
-  (unless (bobp)
-    (eq (get-text-property (1- (point-at-eol)) 'face)
-        'font-lock-doc-face)))
+  (eq (get-text-property (point) 'face) 'font-lock-doc-face))
 
 (defsubst clojure-docstring-fill-prefix ()
   "The prefix string used by `clojure-fill-paragraph'.


### PR DESCRIPTION
The problem in #295 is caused by us checking the text property of the
character penultimate character in the current line.  When point is at
the beginning of the buffer we're asking for the property at position 0,
which doesn't exist.

The solution is to not worry about what the text property is for the
penultimate character of the current line and instead of check what it
is at the position of point.  This has the benefit of aligning the
function result, name and docstring :)