### PR TITLE
Fixed font-locking for def* with support of special chars

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -380,7 +380,7 @@ Called by `imenu--generic-function'."
        (2 font-lock-type-face nil t))
       ;; Function definition (anything that starts with def and is not
       ;; listed above)
-      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def[^ ]*\\)"
+      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def[^ \r\n\t]*\\)"
                 ;; Function declarations
                 "\\>"
                 ;; Any whitespace

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -380,7 +380,7 @@ Called by `imenu--generic-function'."
        (2 font-lock-type-face nil t))
       ;; Function definition (anything that starts with def and is not
       ;; listed above)
-      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def\[a-z\-\]*-?\\)"
+      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def[^ ]*\\)"
                 ;; Function declarations
                 "\\>"
                 ;; Any whitespace


### PR DESCRIPTION
changed the regex to match "def" + anything until the first space " ",
this support font locking for things like `defabc*`, `defyyy!`, etc