### PR TITLE
Fix for error in `clojure-expected-ns`.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -997,8 +997,8 @@ nil."
 PATH is expected to be an absolute file path.
 
 If PATH is nil, use the path to the file backing the current buffer."
-  (let* ((relative (clojure-project-relative-path
-                    (or path (file-truename (buffer-file-name)))))
+  (let* ((path (or path (file-truename (buffer-file-name))))
+         (relative (clojure-project-relative-path path))
          (sans-file-type (substring relative 0 (- (length (file-name-extension path t)))))
          (sans-file-sep (mapconcat 'identity (cdr (split-string sans-file-type "/")) "."))
          (sans-underscores (replace-regexp-in-string "_" "-" sans-file-sep)))

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -42,7 +42,16 @@
     (cl-letf (((symbol-function 'clojure-project-relative-path)
                (lambda (&optional current-buffer-file-name)
                  project-relative-clj-file-path)))
-      (should (string= (clojure-expected-ns clj-file-path) clj-file-ns)))))
+      (should (string= (clojure-expected-ns clj-file-path) clj-file-ns))))
+
+  (ert-deftest expected-ns-without-argument ()
+    :tags '(utils)
+    (cl-letf (((symbol-function 'clojure-project-relative-path)
+               (lambda (&optional current-buffer-file-name)
+                 project-relative-clj-file-path)))
+      (should (string= (let ((buffer-file-name clj-file-path))
+                         (clojure-expected-ns))
+                       clj-file-ns)))))
 
 (provide 'clojure-mode-util-test)
 


### PR DESCRIPTION
When call `clojure-expected-ns` function without arguments,
error occurred.

related commit: 4be6843