### PR TITLE
Fixed font-locking for def* with support of special chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#302](https://github.com/clojure-emacs/clojure-mode/pull/302): Add new sexp navigation commands. `clojure-forward-logical-sexp` and `clojure-backward-logical-sexp` consider `^hints` and `#reader.macros` to be part of the sexp that follows them.
 * [#303](https://github.com/clojure-emacs/clojure-mode/issues/303): Handle `boot` projects in `clojure-expected-ns`.
 
+### Bugs fixed
+
+* Fix font-locking for def with special chars such as: `defn*`, `defspecial!`.
+
 ## 4.1.0 (20/06/2015)
 
 ### Changes

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -380,7 +380,7 @@ Called by `imenu--generic-function'."
        (2 font-lock-type-face nil t))
       ;; Function definition (anything that starts with def and is not
       ;; listed above)
-      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def\[a-z\-\]*-?\\)"
+      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def[^ \r\n\t]*\\)"
                 ;; Function declarations
                 "\\>"
                 ;; Any whitespace

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -172,6 +172,18 @@ POS."
     (should (eq (clojure-test-face-at 2 5) 'font-lock-keyword-face))
     (should (eq (clojure-test-face-at 7 9) 'font-lock-function-name-face))))
 
+(ert-deftest clojure-mode-syntax-table/custom-def-with-special-chars1 ()
+  :tags '(fontification syntax-table)
+  (clojure-test-with-temp-buffer "(defn* foo [x] x)"
+    (should (eq (clojure-test-face-at 2 6) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 8 10) 'font-lock-function-name-face))))
+
+(ert-deftest clojure-mode-syntax-table/custom-def-with-special-chars2 ()
+  :tags '(fontification syntax-table)
+  (clojure-test-with-temp-buffer "(defsomething! foo [x] x)"
+    (should (eq (clojure-test-face-at 2 14) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 16 18) 'font-lock-function-name-face))))
+
 (ert-deftest clojure-mode-syntax-table/lambda-params ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "#(+ % %2 %3)"


### PR DESCRIPTION
changed the regex to match "def" + anything until the first space " " (or blank),
this support font locking for things like `defabc*`, `defyyy!`, etc.
