### PR TITLE
Improve clojure-find-def matching (support hyphens)

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1103,7 +1103,7 @@ Useful if a file has been renamed."
 Returns a list pair, e.g. (\"defn\" \"abc\") or (\"deftest\" \"some-test\")."
   (let ((re (concat "(\\(?:\\(?:\\sw\\|\\s_\\)+/\\)?"
                     ;; Declaration
-                    "\\(def\\sw*\\)\\>"
+                    "\\(def\\(?:\\sw\\|\\s_\\)*\\)\\>"
                     ;; Any whitespace
                     "[ \r\n\t]*"
                     ;; Possibly type or metadata

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -214,6 +214,12 @@ POS."
     (should (eq (clojure-test-face-at 2 14) 'font-lock-keyword-face))
     (should (eq (clojure-test-face-at 16 18) 'font-lock-function-name-face))))
 
+(ert-deftest clojure-mode-syntax-table/custom-def-with-special-chars3 ()
+  :tags '(fontification syntax-table)
+  (clojure-test-with-temp-buffer "(def-something foo [x] x)"
+    (should (eq (clojure-test-face-at 2 14) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 16 18) 'font-lock-function-name-face))))
+
 (ert-deftest clojure-mode-syntax-table/lambda-params ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "#(+ % %2 %3)"


### PR DESCRIPTION
Custom def... macros might contain hyphens (e.g. defxxx-yyy).