### PR TITLE
Form alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Vertically align sexps with `C-c SPC`. This can also be done automatically (as part of indentation) by turning on `clojure-align-forms-automatically`.
 * Indent and font-lock forms that start with `let-`, `while-` or `when-` like their counterparts.
 * Apply the `font-lock-comment-face` to code commented out with `#_`.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ For instructions on how to write these specifications, see
 [this document](https://github.com/clojure-emacs/cider/blob/master/doc/Indent-Spec.md#indent-specification).
 The only difference is that you're allowed to use lists instead of vectors.
 
+### Vertical aligment
+
+You can vertically align sexps with `C-c SPC`. For instance, typing
+this combo on the following form:
+
+```clj
+(def my-map
+  {:a-key 1
+   :other-key 2})
+```
+
+Leads to the following:
+
+```clj
+(def my-map
+  {:a-key     1
+   :other-key 2})
+```
+
+This can also be done automatically (as part of indentation) by
+turning on `clojure-align-forms-automatically`. This way it will
+happen whenever you select some code and hit `TAB`.
+
 ## Related packages
 
 * [clojure-mode-extra-font-locking][] provides additional font-locking

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1191,6 +1191,7 @@ Sexps that don't represent code are ^metadata or #reader.macros."
 This will skip over sexps that don't represent objects, so that ^hints and
 #reader.macros are considered part of the following sexp."
   (interactive "p")
+  (unless n (setq n 1))
   (if (< n 0)
       (clojure-backward-logical-sexp (- n))
     (let ((forward-sexp-function nil))
@@ -1206,6 +1207,7 @@ This will skip over sexps that don't represent objects, so that ^hints and
 This will skip over sexps that don't represent objects, so that ^hints and
 #reader.macros are considered part of the following sexp."
   (interactive "p")
+  (unless n (setq n 1))
   (if (< n 0)
       (clojure-forward-logical-sexp (- n))
     (let ((forward-sexp-function nil))


### PR DESCRIPTION
Much nicer now.
This hooks into indent-line, so that no extra commands are required. 

If the user wants, a command is provided as well. We could bind it to `C-c SPC` in analogy to `C-x SPC`.