### PR TITLE
Fix font-locking: '#', '*', '_', '+' in namespace alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Indent and font-lock forms that start with `let-`, `while-` or `when-` like their counterparts.
+* Fix font-locking: '#', '*', '_', '+' in namespace alias
 
 ## 5.0.1 (15/11/2015)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -381,7 +381,8 @@ Called by `imenu--generic-function'."
        (2 font-lock-type-face nil t))
       ;; Function definition (anything that starts with def and is not
       ;; listed above)
-      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def[^ \r\n\t]*\\)"
+      (,(concat "(\\(?:[_a-z\*\.-\\+]\\{1\\}[_a-z0-9#\*\.-\\+]+/\\)?"
+                "\\(def[^ \r\n\t]*\\)"
                 ;; Function declarations
                 "\\>"
                 ;; Any whitespace

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -56,6 +56,10 @@
 
 
 
+;; '[', ']' must be treated in a special way. See
+;; http://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Special.html
+(string-match "[^][0-9\";\'@\\^`~\(\)\{\}\\]" "teststr")
+
 (eval-when-compile
   (defvar calculate-lisp-indent-last-sexp)
   (defvar font-lock-beg)


### PR DESCRIPTION
(M-x clojure-mode-display-version) gives me:
clojure-mode (version 5.0.1)
