### PR TITLE
[Fix #343] Don't font-lock the `:` in keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Don't font-lock the `:` in keywords.
 * Indent and font-lock forms that start with `let-`, `while-` or `when-` like their counterparts.
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -463,7 +463,7 @@ Called by `imenu--generic-function'."
       ;; foo/ Foo/ @Foo/ /FooBar
       ("\\(?:\\<:?\\|\\.\\)@?\\([a-zA-Z][.a-zA-Z0-9$_-]*\\)\\(/\\)" (1 font-lock-type-face) (2 'default))
       ;; Constant values (keywords), including as metadata e.g. ^:static
-      ("\\<^?\\(:\\(\\sw\\|\\s_\\)+\\(\\>\\|\\_>\\)\\)" 1 'clojure-keyword-face append)
+      ("\\<^?::?\\(\\(\\sw\\|\\s_\\)+\\(\\>\\|\\_>\\)\\)" 1 'clojure-keyword-face append)
       ;; Java interop highlighting
       ;; CONST SOME_CONST (optionally prefixed by /)
       ("\\(?:\\<\\|/\\)\\([A-Z]+\\|\\([A-Z]+_[A-Z1-9_]+\\)\\)\\>" 1 font-lock-constant-face)

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -101,7 +101,8 @@ POS."
 
 (ert-deftest clojure-mode-syntax-table/fontify-clojure-keyword ()
   :tags '(fontification syntax-table)
-  (should (equal (clojure-test-face-at 2 11 "{:something 20}") '(clojure-keyword-face))))
+  (should (equal (clojure-test-face-at 3 11 "{:something 20}") '(clojure-keyword-face)))
+  (should (equal (clojure-test-face-at 2 3 "{:something 20}") 'various-faces)))
 
 (ert-deftest clojure-mode-syntax-table/stuff-in-backticks ()
   :tags '(fontification syntax-table)
@@ -115,11 +116,11 @@ POS."
 
 (ert-deftest clojure-mode-syntax-table/fontify-namespaced-keyword ()
   :tags '(fontification syntax-table)
-  (should (equal (clojure-test-face-at 2 2 "{:alias/some 20}")  '(clojure-keyword-face)))
+  (should (equal (clojure-test-face-at 2 3 "{:alias/some 20}")  'various-faces))
   (should (equal (clojure-test-face-at 3 7 "{:alias/some 20}")  '(font-lock-type-face clojure-keyword-face)))
   (should (equal (clojure-test-face-at 8 8 "{:alias/some 20}")  '(default clojure-keyword-face)))
   (should (equal (clojure-test-face-at 9 12 "{:alias/some 20}") '(clojure-keyword-face)))
-  (should (equal (clojure-test-face-at 2 2 "{:a.ias/some 20}")  '(clojure-keyword-face)))
+  (should (equal (clojure-test-face-at 2 3 "{:a.ias/some 20}")  'various-faces))
   (should (equal (clojure-test-face-at 3 7 "{:a.ias/some 20}")  '(font-lock-type-face clojure-keyword-face)))
   (should (equal (clojure-test-face-at 8 8 "{:a.ias/some 20}")  '(default clojure-keyword-face)))
   (should (equal (clojure-test-face-at 9 12 "{:a.ias/some 20}") '(clojure-keyword-face))))
@@ -261,8 +262,8 @@ POS."
 (ert-deftest clojure-mode-syntax-table/keyword-meta ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "^:meta-data"
-    (should (eq (clojure-test-face-at 1 1) nil))
-    (should (equal (clojure-test-face-at 2 11) '(clojure-keyword-face)))))
+    (should (equal (clojure-test-face-at 1 2) nil))
+    (should (equal (clojure-test-face-at 3 11) '(clojure-keyword-face)))))
 
 (ert-deftest clojure-mode-syntax-table/characters ()
   :tags '(fontification syntax-table)


### PR DESCRIPTION
The `:` in keywords were font-locked with the keyword face because we
inherited the rules for font-locking keywords from Elisp.

In Elisp a keyword is a symbol which starts with the `:` character.
Furthermore, the predicates symbolp and keywordp return T for keywords
in Elisp.  This is different from how a keyword is defined, and how it
behaves, in Common-lisp and in Clojure.

In common-lisp the `:` is a hint to the reader that the symbol should be
interned in the keyword package.

Clojure doesn't have a keyword package, but when the reader consumes a
`:` it means that the following symbol is to be stored in the keyword
table, residing in `Keyword.java`.  Unlike in Elisp, the `:` is never
stored anywhere. It's just the way keywords print and syntactic sugar
for keyword creation.

Thus, unlike in elisp, the `:` is a token meant for the reader, and not
part of the keyword itself, and should not be font-locked with the
keyword face.

#### Before

![kw-before](https://cloud.githubusercontent.com/assets/1006557/11502690/a33953b4-983c-11e5-9d1b-d6bdef07c546.PNG)

#### After

![image](https://cloud.githubusercontent.com/assets/1006557/11502698/ad2024b6-983c-11e5-9cd4-1ca866aab64b.png)

Even though it's barely noticeable, I think this has the benefit of looking a lot better, but that part is highly subjective and shouldn't be part of the decision to merge this or not.