### PR TITLE
Namespace font-locking according to clojure.lang.LispReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Indent and font-lock forms that start with `let-`, `while-` or `when-` like their counterparts.
+* Namespace font-locking according to clojure.lang.LispReader
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 ### New features
 
 * Indent and font-lock forms that start with `let-`, `while-` or `when-` like their counterparts.
-* Namespace font-locking according to clojure.lang.LispReader
 
 ### Bugs fixed
 
 * Namespaces can now use the full palette of legal symbol characters.
+* Namespace font-locking according to clojure.lang.LispReader.
 
 ## 5.0.1 (15/11/2015)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -352,12 +352,19 @@ Called by `imenu--generic-function'."
               (set-match-data (list def-beg def-end)))))
         (goto-char start)))))
 
-(eval-when-compile
-  ;; See clojure.lang.LispReader definition and getMacro invocation(s)
-  (defconst clojure-sym-rest-chars "^][\";\'@\\^`~\(\)\{\}\\")
-  (defconst clojure-sym-1st-chars (concat clojure-sym-rest-chars "0-9"))
+(eval-and-compile
+  (defconst clojure-sym-rest-chars "^][\";\'@\\^`~\(\)\{\}\\"
+    "A black list of chars a clojure symbol must not contain. See
+definiton of 'macros': URL `http://git.io/vRGLD'.")
+  (defconst clojure-sym-1st-chars (concat clojure-sym-rest-chars "0-9")
+    "A black list of chars a clojure symbol must not start with. See
+the for-loop: URL `http://git.io/vRGTj' lines:
+URL `http://git.io/vRGIh', URL `http://git.io/vRGLE'
+and value definition of 'macros': URL `http://git.io/vRGLD'.")
   (defconst clojure-sym
-    (concat "[" clojure-sym-1st-chars "][" clojure-sym-rest-chars "]+")))
+    (concat "[" clojure-sym-1st-chars "][" clojure-sym-rest-chars "]+")
+    "A concatenation of black lists:
+`clojure-sym-1st-chars', `clojure-sym-rest-chars'."))
 
 (defconst clojure-font-lock-keywords
   (eval-when-compile

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -352,6 +352,13 @@ Called by `imenu--generic-function'."
               (set-match-data (list def-beg def-end)))))
         (goto-char start)))))
 
+(eval-when-compile
+  ;; See clojure.lang.LispReader definition and getMacro invocation(s)
+  (defconst clojure-sym-rest-chars "^][\";\'@\\^`~\(\)\{\}\\")
+  (defconst clojure-sym-1st-chars (concat clojure-sym-rest-chars "0-9"))
+  (defconst clojure-sym
+    (concat "[" clojure-sym-1st-chars "][" clojure-sym-rest-chars "]+")))
+
 (defconst clojure-font-lock-keywords
   (eval-when-compile
     `(;; Top-level variable definition
@@ -381,7 +388,8 @@ Called by `imenu--generic-function'."
        (2 font-lock-type-face nil t))
       ;; Function definition (anything that starts with def and is not
       ;; listed above)
-      (,(concat "(\\(?:[a-z\.-]+/\\)?\\(def[^ \r\n\t]*\\)"
+      (,(concat "(\\(?:" clojure-sym "/\\)?"
+                "\\(def[^ \r\n\t]*\\)"
                 ;; Function declarations
                 "\\>"
                 ;; Any whitespace
@@ -461,7 +469,8 @@ Called by `imenu--generic-function'."
       ;; Character literals - \1, \a, \newline, \u0000
       ("\\\\\\([[:punct:]]\\|[a-z0-9]+\\>\\)" 0 'clojure-character-face)
       ;; foo/ Foo/ @Foo/ /FooBar
-      ("\\(?:\\<:?\\|\\.\\)@?\\([a-zA-Z][.a-zA-Z0-9$_-]*\\)\\(/\\)" (1 font-lock-type-face) (2 'default))
+      (,(concat "\\(?:\\<:?\\|\\.\\)@?\\(" clojure-sym "\\)\\(/\\)")
+       (1 font-lock-type-face) (2 'default))
       ;; Constant values (keywords), including as metadata e.g. ^:static
       ("\\<^?\\(:\\(\\sw\\|\\s_\\)+\\(\\>\\|\\_>\\)\\)" 1 'clojure-keyword-face append)
       ;; Java interop highlighting

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -196,6 +196,11 @@ POS."
 
 (ert-deftest clojure-mode-syntax-table/namespaced-def ()
   :tags '(fontification syntax-table)
+  (clojure-test-with-temp-buffer "(_c4/defconstrainedfn bar [] nil)"
+    (should (eq (clojure-test-face-at 2 4) 'font-lock-type-face))
+    (should (eq (clojure-test-face-at 5 5) 'default))
+    (should (eq (clojure-test-face-at 6 18) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 23 25) 'font-lock-function-name-face)))
   (clojure-test-with-temp-buffer "(clo/defbar foo nil)"
     (should (eq (clojure-test-face-at 2 4) 'font-lock-type-face))
     (should (eq (clojure-test-face-at 5 5) 'default))


### PR DESCRIPTION
Fix namespace alias font-locking for aliases containing non-letter
charactes like $, 0-9, _, etc.