### PR TITLE
add "update" function to extra-font-locking

### DIFF
--- a/clojure-mode-extra-font-locking.el
+++ b/clojure-mode-extra-font-locking.el
@@ -134,7 +134,7 @@
     "unchecked-remainder" "unchecked-remainder-int" "unchecked-short"
     "unchecked-subtract-int" "unchecked-subtract"
     "underive" "unsigned-bit-shift-right" "unquote" "unquote-splicing"
-    "update-in" "update-proxy" "use" "val" "vals" "var-get" "var-set"
+    "update" "update-in" "update-proxy" "use" "val" "vals" "var-get" "var-set"
     "var?" "vary-meta" "vec" "vector" "vector?" "vector-of" "while"
     "with-bindings" "with-bindings*" "with-in-str" "with-loading-context"
     "with-meta" "with-out-str" "with-precision"


### PR DESCRIPTION
update was added in Clojure 1.7 :

https://github.com/clojure/clojure/blob/master/changes.md#25-update---like-update-in-for-first-level