### PR TITLE
Treat , as a non-logical sexpr character

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1451,7 +1451,7 @@ Returns a list pair, e.g. (\"defn\" \"abc\") or (\"deftest\" \"some-test\")."
 Sexps that don't represent code are ^metadata or #reader.macros."
   (comment-normalize-vars)
   (comment-forward (point-max))
-  (looking-at-p "\\^\\|#[?[:alpha:]]"))
+  (looking-at-p "\\^\\|#[?[:alpha:]]\\|,"))
 
 (defun clojure-forward-logical-sexp (&optional n)
   "Move forward N logical sexps.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1465,6 +1465,7 @@ This will skip over sexps that don't represent objects, so that ^hints and
       (while (> n 0)
         (while (clojure--looking-at-non-logical-sexp)
           (forward-sexp 1))
+        (skip-chars-forward ",")
         ;; The actual sexp
         (forward-sexp 1)
         (setq n (1- n))))))

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -540,6 +540,12 @@ x
  :b {:a  :a
      :aa :a}}")
 
+(def-full-align-test trailing-commas
+  "{:a {:a  :a,
+     :aa :a},
+ :b {:a  :a,
+     :aa :a}}")
+
 
 ;;; Misc
 


### PR DESCRIPTION
This causes clojure-forward-logical-sexp to skip over , when for
instance computing vertical alignments.

Fixes #367