### PR TITLE
Fix multi-airty indention of deftype & defrecord (#389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#389](https://github.com/clojure-emacs/clojure-mode/issues/389): Fixed the indentation of `defrecord` and `deftype` multiple airity protocol forms.
+
 ## 5.5.0 (2016-06-25)
 
 ### New features

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1313,8 +1313,8 @@ work).  To set it from Lisp code, use
   (as-> 2)
 
   (reify '(:defn (1)))
-  (deftype '(2 nil nil (1)))
-  (defrecord '(2 nil nil (1)))
+  (deftype '(2 nil nil (:defn)))
+  (defrecord '(2 nil nil (:defn)))
   (defprotocol '(1 (:defn)))
   (extend 1)
   (extend-protocol '(1 :defn))

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -280,6 +280,15 @@ values of customisable variables."
     ([item a]
      (* a (:qty item)))))")
 
+(def-full-indent-test deftype-allow-multiarity
+  "(deftype Banana []
+  Fruit
+  (subtotal
+    ([item]
+     (* 158 (:qty item)))
+    ([item a]
+     (* a (:qty item)))))")
+
 (def-full-indent-test defprotocol
   "(defprotocol IFoo
   (foo [this]
@@ -325,6 +334,15 @@ values of customisable variables."
   "(defrecord TheNameOfTheRecord [a pretty long argument list]
   SomeType (assoc [_ x]
              (.assoc pretty x 10)))")
+
+(def-full-indent-test defrecord-allow-multiarity
+  "(defrecord Banana []
+  Fruit
+  (subtotal
+    ([item]
+     (* 158 (:qty item)))
+    ([item a]
+     (* a (:qty item)))))")
 
 (def-full-indent-test letfn
   "(letfn [(f [x]


### PR DESCRIPTION
Updated relevant `define-clojure-indent` forms to be consistent with `extend-protocol`.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality) (Not updated as it didn't appear to be applicable)

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md

