### PR TITLE
Symbols in Clojure are allowed to contain `!' and `?'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bugs fixed
 
+* [#392](https://github.com/clojure-emacs/clojure-mode/issues/392): Wrong syntax class for `?` and `!`
+
 * [#389](https://github.com/clojure-emacs/clojure-mode/issues/389): Fixed the indentation of `defrecord` and `deftype` multiple airity protocol forms.
 
 ## 5.5.0 (2016-06-25)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -261,6 +261,8 @@ Out-of-the box clojure-mode understands lein, boot and gradle."
     (modify-syntax-entry ?\] ")[" table)
     (modify-syntax-entry ?^ "'" table)
     (modify-syntax-entry ?@ "'" table)
+    (modify-syntax-entry ?! "w" table)
+    (modify-syntax-entry ?? "w" table)
     ;; Make hash a usual word character
     (modify-syntax-entry ?# "_ p" table)
     table)

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -32,6 +32,16 @@
     (clojure-forward-logical-sexp 1)
     (should (looking-at-p " :a, 2"))))
 
+(ert-deftest test-sexp-with-exclamation ()
+  (with-temp-buffer
+    (insert "foo! bar? baz")
+    (clojure-mode)
+    (goto-char (point-min))
+    (clojure-forward-logical-sexp 1)
+    (should (looking-at-p " bar?"))
+    (clojure-forward-logical-sexp 1)
+    (should (looking-at-p " baz"))))
+
 (ert-deftest test-sexp ()
   (with-temp-buffer
     (insert "^String #macro ^dynamic reverse")


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

- fixes #392 `cider-symbol-at-point` for functions containing `!` and `?`, like `swap!` and `nil?`