### PR TITLE
Add indentation rule for definterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* Fixed indentation of `definterface` to match that of `defprotocol`.
 * [#389](https://github.com/clojure-emacs/clojure-mode/issues/389): Fixed the indentation of `defrecord` and `deftype` multiple airity protocol forms.
 
 ## 5.5.0 (2016-06-25)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1316,6 +1316,7 @@ work).  To set it from Lisp code, use
   (deftype '(2 nil nil (:defn)))
   (defrecord '(2 nil nil (:defn)))
   (defprotocol '(1 (:defn)))
+  (definterface '(1 (:defn)))
   (extend 1)
   (extend-protocol '(1 :defn))
   (extend-type '(1 :defn))

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -297,6 +297,15 @@ values of customisable variables."
     [this]
     \"Why is this over here?\"))")
 
+
+(def-full-indent-test definterface
+  "(definterface IFoo
+  (foo [this]
+    \"Why is this over here?\")
+  (foo-2
+    [this]
+    \"Why is this over here?\"))")
+
 (def-full-indent-test specify
   "(specify obj
   ISwap


### PR DESCRIPTION
A simple change, basically copied existing code from `defprotocol`. I feel that this should be included by default since `definterface` *is* a core form, if not as widely used a form as `defprotocol`.

I followed the contributing guidelines as best I could, let me know if there is anything else you need me to do.

```
clojure-mode version: 5.5.0-SNAPSHOT
emacs version: 24.5.1

Ubuntu Linux 16.04
```

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] ~~You've updated the readme (if adding/changing user-visible functionality)~~

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md

