### PR TITLE
[Fix #399] Fix font-locking of prefix characters inside keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#399](https://github.com/clojure-emacs/clojure-mode/issues/399) Fix fontification of prefix characters inside keywords.
+
 ## 5.5.1 (2016-07-25)
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -258,11 +258,11 @@ Out-of-the box clojure-mode understands lein, boot and gradle."
     (modify-syntax-entry ?\} "){" table)
     (modify-syntax-entry ?\[ "(]" table)
     (modify-syntax-entry ?\] ")[" table)
-    (modify-syntax-entry ?? "_ p" table) ; prefix outside of symbols
+    (modify-syntax-entry ?? "_ p" table) ; ? is a prefix outside symbols
+    (modify-syntax-entry ?# "_ p" table) ; # is allowed inside keywords (#399)
     (modify-syntax-entry ?~ "'" table)
     (modify-syntax-entry ?^ "'" table)
     (modify-syntax-entry ?@ "'" table)
-    (modify-syntax-entry ?# "'" table)
     table)
   "Syntax table for Clojure mode.
 Inherits from `emacs-lisp-mode-syntax-table'.")
@@ -750,7 +750,7 @@ highlighted region)."
   (setq font-lock-defaults
         '(clojure-font-lock-keywords    ; keywords
           nil nil
-          (("+-*/.<>=!?$%_&~^:@" . "w")) ; syntax alist
+          (("+-*/.<>=!?$%_&:" . "w")) ; syntax alist
           nil
           (font-lock-mark-block-function . mark-defun)
           (font-lock-syntactic-face-function

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -298,6 +298,19 @@ POS."
     (should (eq (clojure-test-face-at 1 1) nil))
     (should (equal (clojure-test-face-at 2 11) '(clojure-keyword-face)))))
 
+(ert-deftest clojure-mode-syntax-table/keyword-allowed-chars ()
+  :tags '(fontification syntax-table)
+  (should (equal (clojure-test-face-at 1 8 ":aaa#bbb") '(clojure-keyword-face))))
+
+(ert-deftest clojure-mode-syntax-table/keyword-disallowed-chars ()
+  :tags '(fontification syntax-table)
+  (should (eq (clojure-test-face-at 1 5 ":aaa@bbb") 'various-faces))
+  (should (equal (clojure-test-face-at 1 4 ":aaa@bbb") '(clojure-keyword-face)))
+  (should (eq (clojure-test-face-at 1 5 ":aaa~bbb") 'various-faces))
+  (should (equal (clojure-test-face-at 1 4 ":aaa~bbb") '(clojure-keyword-face)))
+  (should (eq (clojure-test-face-at 1 5 ":aaa@bbb") 'various-faces))
+  (should (equal (clojure-test-face-at 1 4 ":aaa@bbb") '(clojure-keyword-face))))
+
 (ert-deftest clojure-mode-syntax-table/characters ()
   :tags '(fontification syntax-table)
   (should (eq (clojure-test-face-at 1 2 "\\a") 'clojure-character-face))


### PR DESCRIPTION

 - declare # with "_ p" syntax
 - no overwrite for #~@^ chars in font-lock syntax table