### PR TITLE
Fix `clojure-refactor-map` var definition

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -226,7 +226,8 @@ Out-of-the box clojure-mode understands lein, boot and gradle."
     (define-key map (kbd "n i") #'clojure-insert-ns-form)
     (define-key map (kbd "n h") #'clojure-insert-ns-form-at-point)
     (define-key map (kbd "n u") #'clojure-update-ns)
-    (define-key map (kbd "n s") #'clojure-sort-ns))
+    (define-key map (kbd "n s") #'clojure-sort-ns)
+    map)
   "Keymap for Clojure refactoring commands.")
 (fset 'clojure-refactor-map clojure-refactor-map)
 


### PR DESCRIPTION
[#442](https://github.com/clojure-emacs/clojure-mode/issues/412): Fix `clojure-refactor` prefix.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [ ] All tests are passing (`make test`) => ** It won't let me run those because of some issues with where emacs is on my PATH. Maybe someone can run them on their side?**
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings => **there's a couple warnings in Emacs 25.1, due to obsolete code.**
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md

