### PR TITLE
Port let related refactorings from clj-refactor.el

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
   allow_failures:
     - env: EMACS=emacs-snapshot
 before_install:
-  # Stable Emacs 24.3
-  - sudo add-apt-repository -y ppa:cassou/emacs
+  # Stable Emacs 24.4
+  - sudo add-apt-repository -y ppa:adrozdoff/emacs
   # Nightly Emacs snapshot builds
   - sudo add-apt-repository -y ppa:ubuntu-elisp/ppa
   # Update and install the Emacs for our environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * New interactive command `clojure-view-grimoire`.
 * New interactive command `clojure-view-style-guide`.
 * Make the refactoring keymap prefix customizable via `clojure-refactor-map-prefix`.
+* Port and rework let related features from clj-refactor. Available features: introduce-let, move to let, forward slurp form into let, backward slurp form into let.
 
 ## 5.5.2 (2016-08-03)
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ specific `clojure-mode` release.**
   - [Threading macros](#threading-macros-related-features)
   - [Cycling things](#cycling-things)
   - [Convert collection](#convert-collection)
+  - [Let expression](#let-expression)
 - [Related packages](#related-packages)
 - [REPL Interaction](#repl-interaction)
   - [Basic REPL](#basic-repl)
@@ -264,15 +265,48 @@ Unwind and remove the threading macro. See demonstration on the
 
 * Cycle privacy
 
-Cycle privacy of `def`s or `defn`s. Use metadata explicitly with setting `clojure-use-metadata-for-privacy` to `t` for `defn`s too. See demonstration on the [clj-refactor.el wiki](https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-cycle-privacy).
+Cycle privacy of `def`s or `defn`s. Use metadata explicitly with setting
+`clojure-use-metadata-for-privacy` to `t` for `defn`s too. See demonstration
+on the [clj-refactor.el wiki](https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-cycle-privacy).
 
 * Cycle if/if-not
 
-Find the closest if or if-not up the syntax tree and toggle it. Also transpose the "else" and "then" branches, keeping the semantics the same as before. See demonstration on the [clj-refactor.el wiki](https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-cycle-if).
+Find the closest if or if-not up the syntax tree and toggle it.
+Also transpose the "else" and "then" branches, keeping the semantics
+the same as before. See demonstration on the [clj-refactor.el wiki](https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-cycle-if).
 
 ### Convert collection
 
 Convert any given collection at point to list, quoted list, map, vector or set.
+
+### Let expression
+
+* Introduce let
+
+Introduce a new let form. Put the current form into its binding form with
+a name provided by the user as a bound name. If called with a numeric prefix
+put the let form Nth level up in the form hierarchy. See demonstration on the
+[clj-refactor.el wiki](https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-introduce-let).
+
+* Move to let
+
+Move the current form to the closest let's binding form. Replace
+all occurrences of the form in the body of the let. See demonstration on the
+[clj-refactor.el wiki](https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-move-to-let).
+
+* Forward slurp form into let
+
+Slurp the next form after the let into the let. Replace all occurrences
+of the bound forms in the form added to the let form. If called with
+a prefix argument slurp the next n forms.
+
+* Backward slurp form into let
+
+Slurp the form before the let into the let. Replace all occurrences
+of the bound forms in the form added to the let form. If called with
+a prefix argument slurp the previous n forms.
+
+`paredit-convolute-sexp` is advised to replace occurrences of bound forms with their bound names when convolute is used on a let form.
 
 ## Related packages
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -11,7 +11,7 @@
 ;; URL: http://github.com/clojure-emacs/clojure-mode
 ;; Keywords: languages clojure clojurescript lisp
 ;; Version: 5.6.0-cvs
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -68,6 +68,7 @@
 (require 'imenu)
 (require 'newcomment)
 (require 'align)
+(require 'subr-x)
 
 (declare-function lisp-fill-paragraph  "lisp-mode" (&optional justify))
 
@@ -227,6 +228,10 @@ Out-of-the box clojure-mode understands lein, boot and gradle."
     (define-key map (kbd "n h") #'clojure-insert-ns-form-at-point)
     (define-key map (kbd "n u") #'clojure-update-ns)
     (define-key map (kbd "n s") #'clojure-sort-ns)
+    (define-key map (kbd "s i") #'clojure-introduce-let)
+    (define-key map (kbd "s m") #'clojure-move-to-let)
+    (define-key map (kbd "s f") #'clojure-let-forward-slurp-sexp)
+    (define-key map (kbd "s b") #'clojure-let-backward-slurp-sexp)
     map)
   "Keymap for Clojure refactoring commands.")
 (fset 'clojure-refactor-map clojure-refactor-map)
@@ -260,6 +265,11 @@ Out-of-the box clojure-mode understands lein, boot and gradle."
          "--"
          ["Unwind once" clojure-unwind]
          ["Fully unwind a threading macro" clojure-unwind-all])
+        ("Let expression"
+         ["Introduce let" clojure-introduce-let]
+         ["Move to let" clojure-move-to-let]
+         ["Forward slurp form into let" clojure-let-forward-slurp-sexp]
+         ["Backward slurp form into let" clojure-let-backward-slurp-sexp])
         ("Documentation"
          ["View a Clojure guide" clojure-view-guide]
          ["View a Clojure reference section" clojure-view-reference-section]
@@ -440,12 +450,22 @@ ENDP and DELIMITER."
 
 (declare-function paredit-open-curly "ext:paredit")
 (declare-function paredit-close-curly "ext:paredit")
+(declare-function paredit-convolute-sexp "ext:paredit")
+
+(defun clojure--replace-let-bindings-and-indent (orig-fun &rest args)
+  "Advise `paredit-convolute-sexp' to replace s-expressions with their bound name if a let form was convoluted."
+  (save-excursion
+    (backward-sexp)
+    (when (looking-back clojure--let-regexp)
+      (clojure--replace-sexps-with-bindings-and-indent))))
 
 (defun clojure-paredit-setup (&optional keymap)
   "Make \"paredit-mode\" play nice with `clojure-mode'.
 
 If an optional KEYMAP is passed the changes are applied to it,
-instead of to `clojure-mode-map'."
+instead of to `clojure-mode-map'.
+Also advice `paredit-convolute-sexp' when used on a let form as drop in
+replacement for `cljr-expand-let`."
   (when (>= paredit-version 21)
     (let ((keymap (or keymap clojure-mode-map)))
       (define-key keymap "{" #'paredit-open-curly)
@@ -453,7 +473,8 @@ instead of to `clojure-mode-map'."
     (add-to-list 'paredit-space-for-delimiter-predicates
                  #'clojure-space-for-delimiter-p)
     (add-to-list 'paredit-space-for-delimiter-predicates
-                 #'clojure-no-space-after-tag)))
+                 #'clojure-no-space-after-tag)
+    (advice-add 'paredit-convolute-sexp :after #'clojure--replace-let-bindings-and-indent)))
 
 (defun clojure-mode-variables ()
   "Set up initial buffer-local variables for Clojure mode."
@@ -1775,6 +1796,18 @@ current sexp."
   :safe #'booleanp
   :type 'boolean)
 
+(defun clojure--point-after (&rest actions)
+  "Return POINT after performing ACTIONS.
+
+An action is either the symbol of a function or a two element
+list of (fn args) to pass to `apply''"
+  (save-excursion
+    (dolist (fn-and-args actions)
+      (let ((f (if (listp fn-and-args) (car fn-and-args) fn-and-args))
+            (args (if (listp fn-and-args) (cdr fn-and-args) nil)))
+        (apply f args)))
+    (point)))
+
 (defun clojure--maybe-unjoin-line ()
   "Undo a `join-line' done by a threading command."
   (when (get-text-property (point) 'clojure-thread-line-joined)
@@ -2060,6 +2093,214 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-cycle-if"
       (insert "-not")
       (forward-sexp 2)
       (transpose-sexps 1)))))
+
+;;; let related stuff
+
+(defvar clojure--let-regexp
+  "\(\\(when-let\\|if-let\\|let\\)\\(\\s-*\\|\\[\\)"
+  "Regexp matching let like expressions, i.e. let, when-let, if-let.
+
+The first match-group is the let expression, the second match-group is the whitespace or the opening square bracket if no whitespace between the let expression and the bracket.")
+
+(defun clojure--goto-let ()
+  "Go to the beginning of the nearest let form."
+  (when (in-string-p)
+    (while (or (not (looking-at "("))
+               (in-string-p))
+      (backward-char)))
+  (ignore-errors
+    (while (not (looking-at clojure--let-regexp))
+      (backward-up-list)))
+  (looking-at clojure--let-regexp))
+
+(defun clojure--inside-let-binding-p ()
+  (ignore-errors
+    (save-excursion
+      (let ((pos (point)))
+        (clojure--goto-let)
+        (re-search-forward "\\[")
+        (if (< pos (point))
+            nil
+          (forward-sexp)
+          (up-list)
+          (< pos (point)))))))
+
+(defun clojure--beginning-of-current-let-binding ()
+  "Move before the bound name of the current binding.
+Assume that point is in the binding form of a let."
+  (let ((current-point (point)))
+    (clojure--goto-let)
+    (search-forward "[")
+    (forward-char)
+    (while (> current-point (point))
+      (forward-sexp))
+    (backward-sexp 2)))
+
+(defun clojure--previous-line ()
+  "Keep the column position while go the previous line."
+  (let ((col (current-column)))
+    (forward-line -1)
+    (move-to-column col)))
+
+(defun clojure--prepare-to-insert-new-let-binding ()
+  "Move to right place in the let form to insert a new binding and indent."
+  (if (clojure--inside-let-binding-p)
+      (progn
+        (clojure--beginning-of-current-let-binding)
+        (newline-and-indent)
+        (clojure--previous-line)
+        (indent-for-tab-command))
+    (clojure--goto-let)
+    (search-forward "[")
+    (backward-up-list)
+    (forward-sexp)
+    (down-list -1)
+    (backward-char)
+    (if (looking-at "\\[\\s-*\\]")
+        (forward-char)
+      (forward-char)
+      (newline-and-indent))))
+
+(defun clojure--sexp-regexp (sexp)
+  (concat "\\([^[:word:]^-]\\)"
+          (mapconcat #'identity (mapcar 'regexp-quote (split-string sexp))
+                     "[[:space:]\n\r]+")
+          "\\([^[:word:]^-]\\)"))
+
+(defun clojure--replace-sexp-with-binding (bound-name init-expr end)
+  (save-excursion
+    (while (re-search-forward (clojure--sexp-regexp init-expr) end t)
+      (replace-match (concat "\\1" bound-name "\\2")))))
+
+(defun clojure--replace-sexps-with-bindings (bindings end)
+  "Replace bindings with their respective bound names in the let form.
+BINDINGS is the list of bound names and init expressions, END denotes the end of the let expression."
+  (let ((bound-name (pop bindings))
+        (init-expr (pop bindings)))
+    (when bound-name
+      (clojure--replace-sexp-with-binding bound-name init-expr end)
+      (clojure--replace-sexps-with-bindings bindings end))))
+
+(defun clojure--replace-sexps-with-bindings-and-indent ()
+  (clojure--replace-sexps-with-bindings
+   (clojure--read-let-bindings)
+   (clojure--point-after 'clojure--goto-let 'forward-sexp))
+  (clojure-indent-region
+   (clojure--point-after 'clojure--goto-let)
+   (clojure--point-after 'clojure--goto-let 'forward-sexp)))
+
+(defun clojure--read-let-bindings ()
+  "Read the bound-name and init expression pairs in the binding form.
+Return a list: odd elements are bound names, even elements init expressions."
+  (clojure--goto-let)
+  (down-list 2)
+  (backward-char)
+  (let* ((start (point))
+         (sexp-start start)
+         (end (save-excursion
+                (forward-sexp)
+                (down-list -1)
+                (point)))
+         bindings)
+    (forward-char)
+    (while (/= sexp-start end)
+      (forward-sexp)
+      (let ((sexp (buffer-substring-no-properties sexp-start (point))))
+        (push (string-trim
+               (if (= start sexp-start)
+                   (substring sexp 1)
+                 sexp))
+              bindings))
+      (setq sexp-start (point)))
+    (nreverse bindings)))
+
+(defun clojure--introduce-let-internal (name &optional n)
+  (if (numberp n)
+      (let ((init-expr-sexp (clojure-delete-and-extract-sexp)))
+        (insert name)
+        (ignore-errors (backward-up-list n))
+        (insert "(let" (clojure-delete-and-extract-sexp) ")")
+        (backward-sexp)
+        (down-list)
+        (forward-sexp)
+        (insert " [" name " " init-expr-sexp "]\n")
+        (clojure--replace-sexps-with-bindings-and-indent))
+    (insert "[ " (clojure-delete-and-extract-sexp) "]")
+    (backward-sexp)
+    (insert "(let " (clojure-delete-and-extract-sexp) ")")
+    (backward-sexp)
+    (down-list 2)
+    (insert name)
+    (forward-sexp)
+    (up-list)
+    (newline-and-indent)
+    (insert name)))
+
+(defun clojure--move-to-let-internal (name)
+  (if (not (save-excursion (clojure--goto-let)))
+      (clojure--introduce-let-internal name)
+    (let ((contents (clojure-delete-and-extract-sexp)))
+      (insert name)
+      (clojure--prepare-to-insert-new-let-binding)
+      (insert contents)
+      (backward-sexp)
+      (insert " ")
+      (backward-char)
+      (insert name)
+      (clojure--replace-sexps-with-bindings-and-indent))))
+
+(defun clojure--let-backward-slurp-sexp-internal ()
+  "Slurp the s-expression before the let form into the let form."
+  (clojure--goto-let)
+  (backward-sexp)
+  (let ((sexp (string-trim (clojure-delete-and-extract-sexp))))
+    (delete-blank-lines)
+    (down-list)
+    (forward-sexp 2)
+    (newline-and-indent)
+    (insert sexp)
+    (clojure--replace-sexps-with-bindings-and-indent)))
+
+;;;###autoload
+(defun clojure-let-backward-slurp-sexp (&optional n)
+  "Slurp the s-expression before the let form into the let form.
+With a numberic prefix argument slurp the previous N s-expression into the let form."
+  (interactive "p")
+  (unless n (setq n 1))
+  (dotimes (k n)
+    (save-excursion (clojure--let-backward-slurp-sexp-internal))))
+
+(defun clojure--let-forward-slurp-sexp-internal ()
+  "Slurp the next s-expression after the let form into the let form."
+  (clojure--goto-let)
+  (forward-sexp)
+  (let ((sexp (string-trim (clojure-delete-and-extract-sexp))))
+    (down-list -1)
+    (newline-and-indent)
+    (insert sexp)
+    (clojure--replace-sexps-with-bindings-and-indent)))
+
+;;;###autoload
+(defun clojure-let-forward-slurp-sexp (&optional n)
+  "Slurp the next s-expression after the let form into the let form.
+With a numeric prefix argument slurp the next N s-expressions into the let form."
+  (interactive "p")
+  (unless n (setq n 1))
+  (dotimes (k n)
+    (save-excursion (clojure--let-forward-slurp-sexp-internal))))
+
+;;;###autoload
+(defun clojure-introduce-let (&optional n)
+  "Create a let form, binding the form at point.
+With a numeric prefix argument the let is introduced N lists up."
+  (interactive "P")
+  (clojure--introduce-let-internal (read-from-minibuffer "Name of bound symbol: ") n))
+
+;;;###autoload
+(defun clojure-move-to-let ()
+  "Move the form at point to a binding in the nearest let."
+  (interactive)
+  (clojure--move-to-let-internal (read-from-minibuffer "Name of bound symbol: ")))
 
 
 ;;; ClojureScript

--- a/test/clojure-mode-refactor-let-test.el
+++ b/test/clojure-mode-refactor-let-test.el
@@ -1,0 +1,213 @@
+;;; clojure-mode-refactor-let-test.el --- Clojure Mode: refactor let  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016 Benedek Fazekas <benedek.fazekas@gmail.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; The refactor-let code originally was implemented in clj-refactor.el
+;; and is the work of the clj-reafctor.el team.
+
+;;; Code:
+
+(require 'clojure-mode)
+(require 'ert)
+
+(def-refactor-test test-introduce-let
+  "{:status 200
+ :body (find-body abc)}"
+  "{:status 200
+ :body (let [body (find-body abc)]
+         body)}"
+  (search-backward "(find-body")
+  (clojure--introduce-let-internal "body"))
+
+(def-refactor-test test-introduce-expanded-let
+  "(defn handle-request []
+  {:status 200
+   :length (count (find-body abc))
+   :body (find-body abc)})"
+  "(defn handle-request []
+  (let [body (find-body abc)]
+    {:status 200
+     :length (count body)
+     :body body}))"
+  (search-backward "(find-body")
+  (clojure--introduce-let-internal "body" 1))
+
+(def-refactor-test test-let-replace-bindings-whitespace
+  "(defn handle-request []
+  {:status 200
+   :length (count
+             (find-body
+               abc))
+   :body (find-body abc)})"
+  "(defn handle-request []
+  (let [body (find-body abc)]
+    {:status 200
+     :length (count
+              body)
+     :body body}))"
+  (search-backward "(find-body")
+  (clojure--introduce-let-internal "body" 1))
+
+(def-refactor-test test-let-forward-slurp-sexp
+  "(defn handle-request []
+  (let [body (find-body abc)]
+    {:status 200
+     :length (count body)
+     :body body})
+  (println (find-body abc))
+  (println \"foobar\"))"
+  "(defn handle-request []
+  (let [body (find-body abc)]
+    {:status 200
+     :length (count body)
+     :body body}
+    (println body)
+    (println \"foobar\")))"
+  (search-backward "(count body")
+  (clojure-let-forward-slurp-sexp 2))
+
+(def-refactor-test test-let-backward-slurp-sexp
+    "(defn handle-request []
+  (println (find-body abc))
+  (println \"foobar\")
+  (let [body (find-body abc)]
+    {:status 200
+     :length (count body)
+     :body body}))"
+  "(defn handle-request []
+  (let [body (find-body abc)]
+    (println body)
+    (println \"foobar\")
+    {:status 200
+     :length (count body)
+     :body body}))"
+  (search-backward "(count body")
+  (clojure-let-backward-slurp-sexp 2))
+
+(def-refactor-test test-move-sexp-to-let
+  "(defn handle-request
+  (let [body (find-body abc)]
+    {:status (or status 500)
+     :body body}))"
+  "(defn handle-request
+  (let [body (find-body abc)
+        status (or status 500)]
+    {:status status
+     :body body}))"
+  (search-backward "(or ")
+  (clojure--move-to-let-internal "status"))
+
+(def-refactor-test test-move-constant-to-when-let
+  "(defn handle-request
+  (when-let [body (find-body abc)]
+    {:status 42
+     :body body}))"
+  "(defn handle-request
+  (when-let [body (find-body abc)
+             status 42]
+    {:status status
+     :body body}))"
+  (search-backward "42")
+  (clojure--move-to-let-internal "status"))
+
+(def-refactor-test test-move-to-empty-let
+  "(defn handle-request
+  (if-let []
+    {:status (or status 500)
+     :body body}))"
+  "(defn handle-request
+  (if-let [status (or status 500)]
+    {:status status
+     :body body}))"
+  (search-backward "(or ")
+  (clojure--move-to-let-internal "status"))
+
+(def-refactor-test test-introduce-let-at-move-to-let-if-missing
+  "(defn handle-request
+  {:status (or status 500)
+   :body body})"
+  "(defn handle-request
+  {:status (let [status (or status 500)]
+             status)
+   :body body})"
+  (search-backward "(or ")
+  (clojure--move-to-let-internal "status"))
+
+(def-refactor-test test-move-to-let-multiple-occurrences
+  "(defn handle-request
+  (let []
+    (println \"body: \" body \", params: \" \", status: \" (or status 500))
+    {:status (or status 500)
+     :body body}))"
+  "(defn handle-request
+  (let [status (or status 500)]
+    (println \"body: \" body \", params: \" \", status: \" status)
+    {:status status
+     :body body}))"
+  (search-backward "(or ")
+  (clojure--move-to-let-internal "status"))
+
+;; clojure-emacs/clj-refactor.el#41
+(def-refactor-test test-move-to-let-nested-scope
+  "(defn foo []
+  (let [x (range 10)]
+    (doseq [x (range 10)]
+      (let [x2 (* x x)]))
+    (+ 1 1)))"
+  "(defn foo []
+  (let [x (range 10)
+        something (+ 1 1)]
+    (doseq [x x]
+      (let [x2 (* x x)]))
+    something))"
+  (search-backward "(+ 1 1")
+  (clojure--move-to-let-internal "something"))
+
+;; clojure-emacs/clj-refactor.el#30
+(def-refactor-test test-move-to-let-already-inside-let-binding-1
+  "(deftest retrieve-order-body-test
+  (let [item (get-in (retrieve-order-body order-item-response-str))]))"
+  "(deftest retrieve-order-body-test
+  (let [something (retrieve-order-body order-item-response-str)
+        item (get-in something)]))"
+  (search-backward "(retrieve")
+  (clojure--move-to-let-internal "something"))
+
+;; clojure-emacs/clj-refactor.el#30
+(def-refactor-test test-move-to-let-already-inside-let-binding-2
+  "(let [parent (.getParent (io/file root adrf))
+      builder (string-builder)
+      normalize-path (comp (partial path/relative-to root)
+                           path/->normalized
+                           foobar)]
+  (do-something-spectacular parent builder))"
+  "(let [parent (.getParent (io/file root adrf))
+      builder (string-builder)
+      something (partial path/relative-to root)
+      normalize-path (comp something
+                           path/->normalized
+                           foobar)]
+  (do-something-spectacular parent builder))"
+  (search-backward "(partial")
+  (clojure--move-to-let-internal "something"))
+
+(provide 'clojure-mode-refactor-let-test)
+
+;;; clojure-mode-refactor-let-test.el ends here


### PR DESCRIPTION
Migrate introduce let, move to let from clj-refactor.el. Add introduce
expanded let, forward slurp into let and backward slurp into let.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Implementation follows the main outlines of the cljr code but is
reworked at certain places. Major differences are as follows:
- Expanded let is introduced: with a prefix argument let introduced N
lists up with all the occurrences of bound form replaced at addition
time.
- New function: slurp function into let form forward and backward. Added
value again is to replace bounded forms with their bound names in the
slurped forms. prefix argument can be used again to slurp multiple forms
into the let.
- Expand let is not ported from cljr. Instead `paredit-convolute-sexp`
is advised to replace forms with bound names when used on let like form.

Further notes:
- `string-trim` is moved upstream from cider (after merging this, cider
can be refactored to use the trim fns from `clojure-mode`)

Advise `paredit-convolute-sexp` when used on a let form as drop in replacement for `cljr-expand-let`.