### PR TITLE
Avoid throwing inside `clojure-match-next-def` on 0 arity def-like forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Make `clojure-match-next-def` more robust against zero-arity def-like forms.
+
 ### New features
 
 * New interactive command `clojure-cycle-when`.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -664,7 +664,9 @@ Called by `imenu--generic-function'."
         (down-list)
         (forward-sexp)
         (while (not found?)
-          (forward-sexp)
+          (condition-case nil
+              (forward-sexp)
+            (error nil))
           (or (if (char-equal ?[ (char-after (point)))
                               (backward-sexp))
                   (if (char-equal ?) (char-after (point)))


### PR DESCRIPTION
Fixes #423