### PR TITLE
Include defmethod dispatch key in imenu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### New features
 
+* Add imenu support for multimethods
 * New interactive command `clojure-cycle-when`.
 * New interactive command `clojure-cycle-not`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### New features
 
 * Add imenu support for multimethods
+* Make imenu recognize indented def-forms
 * New interactive command `clojure-cycle-when`.
 * New interactive command `clojure-cycle-not`.
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -657,23 +657,28 @@ and `(match-end 1)'."
 Called by `imenu--generic-function'."
   ;; we have to take into account namespace-definition forms
   ;; e.g. s/defn
-  (when (re-search-backward "^(\\([a-z0-9.-]+/\\)?def\\sw*" nil t)
+  (when (re-search-backward "^(\\([a-z0-9.-]+/\\)?\\(def\\sw*\\)" nil t)
     (save-excursion
       (let (found?
+            (deftype (match-string 2))
             (start (point)))
         (down-list)
         (forward-sexp)
         (while (not found?)
           (ignore-errors
             (forward-sexp))
-          (or (if (char-equal ?[ (char-after (point)))
-                              (backward-sexp))
-                  (if (char-equal ?) (char-after (point)))
+          (or (when (char-equal ?[ (char-after (point)))
+                (backward-sexp))
+              (when (char-equal ?) (char-after (point)))
                 (backward-sexp)))
           (cl-destructuring-bind (def-beg . def-end) (bounds-of-thing-at-point 'sexp)
             (if (char-equal ?^ (char-after def-beg))
                 (progn (forward-sexp) (backward-sexp))
               (setq found? t)
+              (when (string= deftype "defmethod")
+                (setq def-end (progn (goto-char def-end)
+                                     (forward-sexp)
+                                     (point))))
               (set-match-data (list def-beg def-end)))))
         (goto-char start)))))
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -657,7 +657,7 @@ and `(match-end 1)'."
 Called by `imenu--generic-function'."
   ;; we have to take into account namespace-definition forms
   ;; e.g. s/defn
-  (when (re-search-backward "^(\\([a-z0-9.-]+/\\)?\\(def\\sw*\\)" nil t)
+  (when (re-search-backward "^[ \t]*(\\([a-z0-9.-]+/\\)?\\(def\\sw*\\)" nil t)
     (save-excursion
       (let (found?
             (deftype (match-string 2))


### PR DESCRIPTION
All`(defmethod foo dispatch-key ...)` currently show as `foo` in imenu. Fix that by including corresponding `dispatch-key` into imenu items.

I have also replaced cl-destructuring-bind with let as it doesn't work with edebug in emacs 25.2.2. Cannot dig into that at the moment.