### PR TITLE
Remove ; from paragraph-start regexp during fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* Fix fill-paragraph in multi-line comments.
 * [#429](https://github.com/clojure-emacs/clojure-mode/issues/429): Fix a bug causing last occurrence of expression sometimes is not replaced when using `move-to-let`.
 * [#423](https://github.com/clojure-emacs/clojure-mode/issues/423): Make `clojure-match-next-def` more robust against zero-arity def-like forms.
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -579,14 +579,14 @@ If JUSTIFY is non-nil, justify as well as fill the paragraph."
   (if (clojure-in-docstring-p)
       (let ((paragraph-start
              (concat paragraph-start
-                     "\\|\\s-*\\([(;:\"[]\\|~@\\|`(\\|#'(\\)"))
+                     "\\|\\s-*\\([(:\"[]\\|~@\\|`(\\|#'(\\)"))
             (paragraph-separate
              (concat paragraph-separate "\\|\\s-*\".*[,\\.]$"))
             (fill-column (or clojure-docstring-fill-column fill-column))
             (fill-prefix (clojure-docstring-fill-prefix)))
         (fill-paragraph justify))
     (let ((paragraph-start (concat paragraph-start
-                                   "\\|\\s-*\\([(;:\"[]\\|`(\\|#'(\\)"))
+                                   "\\|\\s-*\\([(:\"[]\\|`(\\|#'(\\)"))
           (paragraph-separate
            (concat paragraph-separate "\\|\\s-*\".*[,\\.[]$")))
       (or (fill-comment-paragraph justify)

--- a/test/clojure-mode-syntax-test.el
+++ b/test/clojure-mode-syntax-test.el
@@ -77,4 +77,32 @@
       (backward-prefix-chars)
       (should (bobp)))))
 
+(def-refactor-test test-paragraph-fill-within-comments
+    "
+;; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+;; ut labore et dolore magna aliqua."
+    "
+;; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+;; tempor incididunt ut labore et dolore magna aliqua."
+  (goto-char (point-min))
+  (let ((fill-column 80))
+    (fill-paragraph)))
+
+(def-refactor-test test-paragraph-fill-within-inner-comments
+    "
+(let [a 1]
+  ;; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+  ;; ut labore et dolore
+  ;; magna aliqua.
+  )"
+    "
+(let [a 1]
+  ;; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+  ;; tempor incididunt ut labore et dolore magna aliqua.
+  )"
+  (goto-char (point-min))
+  (forward-line 2)
+  (let ((fill-column 80))
+    (fill-paragraph)))
+
 (provide 'clojure-mode-syntax-test)


### PR DESCRIPTION
Multi-line comments are not filled correctly. Who thinks that `;` should start a paragraph?

```clj
;; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
;; ut labore et dolore magna aliqua. 
``` 

fill paragraph on first line and get this

```clj
;; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
;; tempor incididunt
;; ut labore et dolore magna aliqua. 
```
