### PR TITLE
Escape character literals for emacs.next

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -679,9 +679,9 @@ Called by `imenu--generic-function'."
         (while (not found?)
           (ignore-errors
             (forward-sexp))
-          (or (when (char-equal ?[ (char-after (point)))
+          (or (when (char-equal ?\[ (char-after (point)))
                 (backward-sexp))
-              (when (char-equal ?) (char-after (point)))
+              (when (char-equal ?\) (char-after (point)))
                 (backward-sexp)))
           (cl-destructuring-bind (def-beg . def-end) (bounds-of-thing-at-point 'sexp)
             (if (char-equal ?^ (char-after def-beg))


### PR DESCRIPTION
In an emacs built yesterday from master, I see the warning generated by [this change](https://github.com/emacs-mirror/emacs/commit/16004397f40d15d9db6b90632c236c804f38fc40). This tiny change seems to make the warnings go away.

I don't believe this requires changelog or readme changes. Also, I haven't added tests, but would not be averse to doing that if someone could point me at how one might intercept warnings like that.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [ ] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
