### PR TITLE
Use evm for TravisCI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 matrix:
   allow_failures:
     - env: EMACS_BINARY=emacs-git-snapshot-travis
+  fast_finish: true
 before_script:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EMACS_BINARY --use --skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
+sudo: false
 language: emacs-lisp
 env:
-  - EMACS=emacs24
-  - EMACS=emacs-snapshot
+  - EMACS_BINARY=emacs-24.4-travis
+  - EMACS_BINARY=emacs-24.5-travis
+  - EMACS_BINARY=emacs-25.1-travis
+  - EMACS_BINARY=emacs-25.2-travis
+  - EMACS_BINARY=emacs-git-snapshot-travis
 matrix:
   allow_failures:
-    - env: EMACS=emacs-snapshot
-before_install:
-  # Stable Emacs 24.4
-  - sudo add-apt-repository -y ppa:adrozdoff/emacs
-  # Nightly Emacs snapshot builds
-  - sudo add-apt-repository -y ppa:ubuntu-elisp/ppa
-  # Update and install the Emacs for our environment
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -yy ${EMACS}-nox
-  # Install and bootstrap cask
-  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
-  - export PATH="${HOME}/.cask/bin:$PATH"
-install:
-  - cask install
+    - env: EMACS_BINARY=emacs-git-snapshot-travis
+before_script:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EMACS_BINARY --use --skip
+  - make elpa
 script:
+  - emacs --version
   - make compile test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 sudo: false
 language: emacs-lisp
 env:
-  - EMACS_BINARY=emacs-24.4-travis
-  - EMACS_BINARY=emacs-24.5-travis
-  - EMACS_BINARY=emacs-25.1-travis
-  - EMACS_BINARY=emacs-25.2-travis
+  - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test
+  - EMACS_BINARY=emacs-24.4-travis MAKE_TEST=test-bytecomp
+  - EMACS_BINARY=emacs-24.5-travis MAKE_TEST=test
+  - EMACS_BINARY=emacs-24.5-travis MAKE_TEST=test-bytecomp
+  - EMACS_BINARY=emacs-25.1-travis MAKE_TEST=test
+  - EMACS_BINARY=emacs-25.1-travis MAKE_TEST=test-bytecomp
+  - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test
+  - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test-bytecomp
+  - EMACS_BINARY=emacs-25.2-travis MAKE_TEST=test-checks
   - EMACS_BINARY=emacs-git-snapshot-travis
 matrix:
   allow_failures:
@@ -15,4 +20,4 @@ before_script:
   - make elpa
 script:
   - emacs --version
-  - make compile test
+  - make $MAKE_TEST

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ OBJS = $(SRCS:.el=.elc)
 
 .PHONY: compile test clean
 
+elpa:
+	$(CASK) install
+	$(CASK) update
+	touch $@
+
 compile: $(OBJS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export EMACS
 
 PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 
-SRCS = clojure-mode.el
+SRCS = $(wildcard *.el)
 OBJS = $(SRCS:.el=.elc)
 
 .PHONY: compile test clean

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,12 @@ clean:
 test: $(PKGDIR)
 	$(CASK) exec ert-runner $(TESTFLAGS)
 
-%.elc : %.el $(PKGDIR)
-	$(CASK) exec $(EMACS) -Q --batch $(EMACSFLAGS) -f batch-byte-compile $<
+test-checks:
+	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
+		-l test/test-checks.el ./
 
-$(PKGDIR) : Cask
-	$(CASK) install
-	touch $(PKGDIR)
+test-bytecomp: $(SRCS:.el=.elc-test)
+
+%.elc-test: %.el elpa
+	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
+		-l test/clojure-mode-bytecomp-warnings.el $

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -185,7 +185,7 @@ For example, \[ is allowed in :db/id[:db.part/user]."
 
 (defcustom clojure-build-tool-files '("project.clj" "build.boot" "build.gradle")
   "A list of files, which identify a Clojure project's root.
-Out-of-the box clojure-mode understands lein, boot and gradle."
+Out-of-the box `clojure-mode' understands lein, boot and gradle."
   :type '(repeat string)
   :package-version '(clojure-mode . "5.0.0")
   :safe (lambda (value)
@@ -317,7 +317,7 @@ CIDER provides a more complex version which does classpath analysis.")
   (message "clojure-mode (version %s)" clojure-mode-version))
 
 (defconst clojure-mode-report-bug-url "https://github.com/clojure-emacs/clojure-mode/issues/new"
-  "The URL to report a clojure-mode issue.")
+  "The URL to report a `clojure-mode' issue.")
 
 (defun clojure-mode-report-bug ()
   "Report a bug in your default browser."
@@ -458,7 +458,14 @@ ENDP and DELIMITER."
 (declare-function paredit-convolute-sexp "ext:paredit")
 
 (defun clojure--replace-let-bindings-and-indent (orig-fun &rest args)
-  "Advise `paredit-convolute-sexp' to replace s-expressions with their bound name if a let form was convoluted."
+  "Advise ORIG-FUN to replace let bindings.
+
+Sexps are replace by their bound name if a let form was
+convoluted.
+
+ORIG-FUN should be `paredit-convolute-sexp'.
+
+ARGS are passed to ORIG-FUN, as with all advice."
   (save-excursion
     (backward-sexp)
     (when (looking-back clojure--let-regexp)
@@ -520,13 +527,14 @@ replacement for `cljr-expand-let`."
   (add-hook 'paredit-mode-hook #'clojure-paredit-setup))
 
 (defcustom clojure-verify-major-mode t
-  "If non-nil, warn when activating the wrong major-mode."
+  "If non-nil, warn when activating the wrong `major-mode'."
   :type 'boolean
   :safe #'booleanp
   :package-version '(clojure-mode "5.3.0"))
 
 (defun clojure--check-wrong-major-mode ()
-  "Check if the current major-mode matches the file extension.
+  "Check if the current `major-mode' matches the file extension.
+
 If it doesn't, issue a warning if `clojure-verify-major-mode' is
 non-nil."
   (when (and clojure-verify-major-mode
@@ -1107,8 +1115,11 @@ Place point as in `clojure--position-for-alignment'."
 
 (defun clojure--search-whitespace-after-next-sexp (&optional bound _noerror)
   "Move point after all whitespace after the next sexp.
+
 Set the match data group 1 to be this region of whitespace and
-return point."
+return point.
+
+BOUND is bounds the whitespace search."
   (unwind-protect
       (ignore-errors
         (clojure-forward-logical-sexp 1)
@@ -1835,6 +1846,9 @@ list of (fn args) to pass to `apply''"
     (insert "\n")))
 
 (defun clojure--unwind-last ()
+  "Unwind a thread last macro once.
+
+Point must be between the opening paren and the ->> symbol."
   (forward-sexp)
   (save-excursion
     (let ((beg (point))
@@ -1857,6 +1871,7 @@ list of (fn args) to pass to `apply''"
   (forward-char))
 
 (defun clojure--ensure-parens-around-function-names ()
+  "Insert parens around function names if necessary."
   (clojure--looking-at-non-logical-sexp)
   (unless (looking-at "(")
     (insert-parentheses 1)
@@ -1864,6 +1879,7 @@ list of (fn args) to pass to `apply''"
 
 (defun clojure--unwind-first ()
   "Unwind a thread first macro once.
+
 Point must be between the opening paren and the -> symbol."
   (forward-sexp)
   (save-excursion
@@ -1879,12 +1895,14 @@ Point must be between the opening paren and the -> symbol."
   (forward-char))
 
 (defun clojure--pop-out-of-threading ()
+  "Raise a sexp up a level to unwind a threading form."
   (save-excursion
     (down-list 2)
     (backward-up-list)
     (raise-sexp)))
 
 (defun clojure--nothing-more-to-unwind ()
+  "Return non-nil if a threaded form cannot be unwound further."
   (save-excursion
     (let ((beg (point)))
       (forward-sexp)
@@ -1895,6 +1913,10 @@ Point must be between the opening paren and the -> symbol."
       (= beg (point)))))
 
 (defun clojure--fix-sexp-whitespace (&optional move-out)
+  "Fix whitespace after unwinding a threading form.
+
+Optional argument MOVE-OUT, if non-nil, means moves up a list
+before fixing whitespace."
   (save-excursion
     (when move-out (backward-up-list))
     (let ((sexp (bounds-of-thing-at-point 'sexp)))
@@ -1933,10 +1955,12 @@ Return nil if there are no more levels to unwind."
   (while (clojure-unwind)))
 
 (defun clojure--remove-superfluous-parens ()
+  "Remove extra parens from a form."
   (when (looking-at "([^ )]+)")
     (delete-pair)))
 
 (defun clojure--thread-first ()
+  "Thread a nested sexp using ->."
   (down-list)
   (forward-symbol 1)
   (unless (looking-at ")")
@@ -1954,6 +1978,7 @@ Return nil if there are no more levels to unwind."
       t)))
 
 (defun clojure--thread-last ()
+  "Thread a nested sexp using ->>."
   (forward-sexp 2)
   (down-list -1)
   (backward-sexp)
@@ -1972,6 +1997,7 @@ Return nil if there are no more levels to unwind."
       t)))
 
 (defun clojure--threadable-p ()
+  "Return non-nil if a form can be threaded."
   (save-excursion
     (forward-symbol 1)
     (looking-at "[\n\r\t ]*(")))
@@ -1993,6 +2019,12 @@ Return nil if there are no more levels to unwind."
       (clojure--fix-sexp-whitespace 'move-out))))
 
 (defun clojure--thread-all (first-or-last-thread but-last)
+  "Fully thread the form at point.
+
+FIRST-OR-LAST-THREAD is \"->\" or \"->>\".
+
+When BUT-LAST is non-nil, the last expression is not threaded.
+Default value is `clojure-thread-all-but-last'."
   (save-excursion
     (insert-parentheses 1)
     (insert first-or-last-thread))
@@ -2003,14 +2035,18 @@ Return nil if there are no more levels to unwind."
 ;;;###autoload
 (defun clojure-thread-first-all (but-last)
   "Fully thread the form at point using ->.
-When BUT-LAST is passed the last expression is not threaded."
+
+When BUT-LAST is non-nil, the last expression is not threaded.
+Default value is `clojure-thread-all-but-last'."
   (interactive "P")
   (clojure--thread-all "-> " but-last))
 
 ;;;###autoload
 (defun clojure-thread-last-all (but-last)
   "Fully thread the form at point using ->>.
-When BUT-LAST is passed the last expression is not threaded."
+
+When BUT-LAST is non-nil, the last expression is not threaded.
+Default value is `clojure-thread-all-but-last'."
   (interactive "P")
   (clojure--thread-all "->> " but-last))
 
@@ -2161,9 +2197,13 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-cycle-if"
 
 (defvar clojure--let-regexp
   "\(\\(when-let\\|if-let\\|let\\)\\(\\s-*\\|\\[\\)"
-  "Regexp matching let like expressions, i.e. let, when-let, if-let.
+  "Regexp matching let like expressions, i.e. \"let\", \"when-let\", \"if-let\".
 
-The first match-group is the let expression, the second match-group is the whitespace or the opening square bracket if no whitespace between the let expression and the bracket.")
+The first match-group is the let expression.
+
+The second match-group is the whitespace or the opening square
+bracket if no whitespace between the let expression and the
+bracket.")
 
 (defun clojure--goto-let ()
   "Go to the beginning of the nearest let form."
@@ -2177,6 +2217,7 @@ The first match-group is the let expression, the second match-group is the white
   (looking-at clojure--let-regexp))
 
 (defun clojure--inside-let-binding-p ()
+  "Return non-nil if point is inside a let binding."
   (ignore-errors
     (save-excursion
       (let ((pos (point)))
@@ -2225,12 +2266,18 @@ Assume that point is in the binding form of a let."
       (newline-and-indent))))
 
 (defun clojure--sexp-regexp (sexp)
+  "Return a regexp for matching SEXP."
   (concat "\\([^[:word:]^-]\\)"
           (mapconcat #'identity (mapcar 'regexp-quote (split-string sexp))
                      "[[:space:]\n\r]+")
           "\\([^[:word:]^-]\\)"))
 
 (defun clojure--replace-sexp-with-binding (bound-name init-expr)
+  "Replace a binding with its bound name in the let form.
+
+BOUND-NAME is the name (left-hand side) of a binding.
+
+INIT-EXPR is the value (right-hand side) of a binding."
   (save-excursion
     (while (re-search-forward
             (clojure--sexp-regexp init-expr)
@@ -2240,6 +2287,7 @@ Assume that point is in the binding form of a let."
 
 (defun clojure--replace-sexps-with-bindings (bindings)
   "Replace bindings with their respective bound names in the let form.
+
 BINDINGS is the list of bound names and init expressions."
   (let ((bound-name (pop bindings))
         (init-expr (pop bindings)))
@@ -2248,6 +2296,7 @@ BINDINGS is the list of bound names and init expressions."
       (clojure--replace-sexps-with-bindings bindings))))
 
 (defun clojure--replace-sexps-with-bindings-and-indent ()
+  "Replace sexps with bindings."
   (clojure--replace-sexps-with-bindings
    (clojure--read-let-bindings))
   (clojure-indent-region
@@ -2277,6 +2326,10 @@ Return a list: odd elements are bound names, even elements init expressions."
     (nreverse bindings)))
 
 (defun clojure--introduce-let-internal (name &optional n)
+  "Create a let form, binding the form at point with NAME.
+
+Optional numeric argument N, if non-nil, introduces the let N
+lists up."
   (if (numberp n)
       (let ((init-expr-sexp (clojure-delete-and-extract-sexp)))
         (insert name)
@@ -2299,6 +2352,7 @@ Return a list: odd elements are bound names, even elements init expressions."
     (insert name)))
 
 (defun clojure--move-to-let-internal (name)
+  "Bind the form at point to NAME in the nearest let."
   (if (not (save-excursion (clojure--goto-let)))
       (clojure--introduce-let-internal name)
     (let ((contents (clojure-delete-and-extract-sexp)))

--- a/test/clojure-mode-bytecomp-warnings.el
+++ b/test/clojure-mode-bytecomp-warnings.el
@@ -1,0 +1,40 @@
+;;; clojure-mode-bytecomp-warnings.el --- Check for byte-compilation problems
+
+;; Copyright © 2012-2017 Bozhidar Batsov and contributors
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; This is a script to be loaded while visiting a `clojure-mode' source file.
+;; It will prepare all requirements and then byte-compile the file and signal an
+;; error on any warning.  For example:
+;;
+;;    emacs -Q --batch -l test/clojure-mode-bytecomp-warnings.el clojure-mode.el
+
+;; This assumes that all `clojure-mode' dependencies are already on the package
+;; dir (probably from running `cask install').
+
+(setq load-prefer-newer t)
+(add-to-list 'load-path (expand-file-name "./"))
+(require 'package)
+(package-generate-autoloads 'clojure-mode default-directory)
+(package-initialize)
+(load-file "clojure-mode-autoloads.el")
+(setq byte-compile-error-on-warn t)
+(batch-byte-compile)
+
+;;; clojure-mode-bytecomp-warnings.el ends here

--- a/test/test-checks.el
+++ b/test/test-checks.el
@@ -1,0 +1,30 @@
+;; This is a script to be loaded from the root `clojure-mode' directory. It will
+;; prepare all requirements and then run `check-declare-directory' on
+;; `default-directory'. For example: emacs -Q --batch -l test/test-checkdoc.el
+
+;; This assumes that all `clojure-mode' dependencies are already on the package
+;; dir (probably from running `cask install').
+
+(add-to-list 'load-path (expand-file-name "./"))
+(require 'package)
+(require 'check-declare)
+(package-initialize)
+
+;; disable some annoying (or non-applicable) checkdoc checks
+(setq checkdoc-package-keywords-flag nil)
+(setq checkdoc-arguments-in-order-flag nil)
+(setq checkdoc-verb-check-experimental-flag nil)
+
+(let ((files (directory-files default-directory t
+                              "\\`[^.].*\\.el\\'" t)))
+
+  ;; `checkdoc-file' was introduced in Emacs 25
+  (when (fboundp 'checkdoc-file)
+    (dolist (file files)
+      (checkdoc-file file))
+    (when (get-buffer "*Warnings*")
+      (message "Failing due to checkdoc warnings...")
+      (kill-emacs 1)))
+
+  (when (apply #'check-declare-files files)
+    (kill-emacs 1)))


### PR DESCRIPTION
Per @bbatsov's [suggestion](https://github.com/clojure-emacs/cider/pull/2059#issuecomment-317231168), we'd like to align TravisCI tests for `clojure-mode` with those of CIDER.