### PR TITLE
Fix typo in docstring

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2373,7 +2373,7 @@ With a numeric prefix argument the let is introduced N lists up."
                 (regexp-opt '("js-obj" "js-delete" "clj->js" "js->clj"))
                 "\\>")
        0 font-lock-builtin-face)))
-  "Additional font-locking for `clojurescrip-mode'.")
+  "Additional font-locking for `clojurescript-mode'.")
 
 ;;;###autoload
 (define-derived-mode clojurescript-mode clojure-mode "ClojureScript"


### PR DESCRIPTION
Fixed a typo I noticed in a docstring
-----------------

- [x] The commits are consistent with our [contribution guidelines][1]


[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md