### PR TITLE
[Fix #443] Don't consider #? as starting non-logical sexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * Fix fill-paragraph in multi-line comments.
+* [#443](https://github.com/clojure-emacs/clojure-mode/issues/443): Fix behavior of `clojure-forward-logical-sexp` and `clojure-backward-logical-sexp` with conditional macros.
 * [#429](https://github.com/clojure-emacs/clojure-mode/issues/429): Fix a bug causing last occurrence of expression sometimes is not replaced when using `move-to-let`.
 * [#423](https://github.com/clojure-emacs/clojure-mode/issues/423): Make `clojure-match-next-def` more robust against zero-arity def-like forms.
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1767,11 +1767,10 @@ Returns a list pair, e.g. (\"defn\" \"abc\") or (\"deftest\" \"some-test\")."
 ;;; Sexp navigation
 (defun clojure--looking-at-non-logical-sexp ()
   "Return non-nil if text after point is \"non-logical\" sexp.
-
 \"Non-logical\" sexp are ^metadata and #reader.macros."
   (comment-normalize-vars)
   (comment-forward (point-max))
-  (looking-at-p "\\^\\|#[?[:alpha:]]"))
+  (looking-at-p "\\^\\|#[[:alpha:]]"))
 
 (defun clojure-forward-logical-sexp (&optional n)
   "Move forward N logical sexps.


### PR DESCRIPTION
Fixing this in a simplest way I can think of. Judging from the docs of `clojure--looking-at-non-logical-sexp` `#?` should not even be considered as non-logical sexps under any circumstances.

I think `?` in that regexp is some kind of legacy remnant. `#?@` are now marked as prefix chars  and `backward-sexp` does the right thing on prefixed sexps. 