### PR TITLE
clojure-mode.el (clojure-mode): Force elec. indentation in a docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#447](https://github.com/clojure-emacs/clojure-mode/issues/241): When `electric-indent-mode` is on, force indentation from within docstrings.
 * [#438](https://github.com/clojure-emacs/clojure-mode/issues/438): Filling within a doc-string doesn't affect surrounding code. 
 * Fix fill-paragraph in multi-line comments.
 * [#443](https://github.com/clojure-emacs/clojure-mode/issues/443): Fix behavior of `clojure-forward-logical-sexp` and `clojure-backward-logical-sexp` with conditional macros.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -525,8 +525,10 @@ replacement for `cljr-expand-let`."
   (clojure-mode-variables)
   (clojure-font-lock-setup)
   (add-hook 'paredit-mode-hook #'clojure-paredit-setup)
+  ;; `electric-layout-post-self-insert-function' prevents indentation in strings
+  ;; and comments, force indentation in docstrings:
   (add-hook 'electric-indent-functions
-            (lambda (c) (if (clojure-in-docstring-p) 'do-indent))))
+            (lambda (char) (if (clojure-in-docstring-p) 'do-indent))))
 
 (defcustom clojure-verify-major-mode t
   "If non-nil, warn when activating the wrong `major-mode'."

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -524,7 +524,9 @@ replacement for `cljr-expand-let`."
 \\{clojure-mode-map}"
   (clojure-mode-variables)
   (clojure-font-lock-setup)
-  (add-hook 'paredit-mode-hook #'clojure-paredit-setup))
+  (add-hook 'paredit-mode-hook #'clojure-paredit-setup)
+  (add-hook 'electric-indent-functions
+            (lambda (c) (if (clojure-in-docstring-p) 'do-indent))))
 
 (defcustom clojure-verify-major-mode t
   "If non-nil, warn when activating the wrong `major-mode'."


### PR DESCRIPTION
By default, `electric-layout-post-self-insert-function` prevents indentation in strings and comments.  When `electric-indent-mode` is on, we want `newline` to reindent the line when the point is within a docstring, so this patch adds a hook to `electric-indent-functions` to that effect.

See https://github.com/clojure-emacs/clojure-mode/issues/241#issuecomment-332323785 for a discussion about this bug.