### PR TITLE
Fix namespace font locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#443](https://github.com/clojure-emacs/clojure-mode/issues/443): Fix behavior of `clojure-forward-logical-sexp` and `clojure-backward-logical-sexp` with conditional macros.
 * [#429](https://github.com/clojure-emacs/clojure-mode/issues/429): Fix a bug causing last occurrence of expression sometimes is not replaced when using `move-to-let`.
 * [#423](https://github.com/clojure-emacs/clojure-mode/issues/423): Make `clojure-match-next-def` more robust against zero-arity def-like forms.
+* Fix namespace font-locking
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [#443](https://github.com/clojure-emacs/clojure-mode/issues/443): Fix behavior of `clojure-forward-logical-sexp` and `clojure-backward-logical-sexp` with conditional macros.
 * [#429](https://github.com/clojure-emacs/clojure-mode/issues/429): Fix a bug causing last occurrence of expression sometimes is not replaced when using `move-to-let`.
 * [#423](https://github.com/clojure-emacs/clojure-mode/issues/423): Make `clojure-match-next-def` more robust against zero-arity def-like forms.
-* Fix namespace font-locking
+* Fix namespace font-locking.
 * [#451](https://github.com/clojure-emacs/clojure-mode/issues/451): Make project root directory calculation customized by `clojure-project-root-function`
 
 ### New features

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -845,19 +845,15 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
       ;; Java interop highlighting
       ;; CONST SOME_CONST (optionally prefixed by /)
       ("\\(?:\\<\\|/\\)\\([A-Z]+\\|\\([A-Z]+_[A-Z1-9_]+\\)\\)\\>" 1 font-lock-constant-face)
-      ;; .foo .barBaz .qux01 .-flibble .-flibbleWobble
-      ("\\<\\.-?[a-z][a-zA-Z0-9]*\\>" 0 'clojure-interop-method-face)
-      ;; Foo Bar$Baz Qux_ World_OpenUDP Foo. Babylon15.
-      ("\\(?:\\<\\|\\.\\|/\\|#?^\\)\\([A-Z][a-zA-Z0-9_]*[a-zA-Z0-9$_]+\\.?\\>\\)" 1 font-lock-type-face)
-      ;; foo.bar.baz
-      ("\\<^?\\([a-z][a-z0-9_-]+\\.\\([a-z][a-z0-9_-]*\\.?\\)+\\)" 1 font-lock-type-face)
-      ;; (ns namespace) - special handling for single segment namespaces
+      ;; special handling for foo.bar.baz in the namespace definition
       (,(concat "(\\<ns\\>[ \r\n\t]*"
                 ;; Possibly metadata
                 "\\(?:\\^?{[^}]+}[ \r\n\t]*\\)*"
                 ;; namespace
-                "\\([a-z0-9-]+\\)")
+                "\\(" clojure--sym-regexp "\\)")
        (1 font-lock-type-face nil t))
+      ;; .foo .barBaz .qux01 .-flibble .-flibbleWobble
+      ("\\<\\.-?[a-z][a-zA-Z0-9]*\\>" 0 'clojure-interop-method-face)
       ;; fooBar
       ("\\(?:\\<\\|/\\)\\([a-z]+[A-Z]+[a-zA-Z0-9$]*\\>\\)" 1 'clojure-interop-method-face)
       ;; #_ and (comment ...) macros.

--- a/test.clj
+++ b/test.clj
@@ -1,7 +1,21 @@
 ;;; font locking
 (ns clojure-mode.demo
-  (:require [clojure.something]
-            [something.s]))
+  (:require
+   [clojure.something]
+   [something.s]
+   [oneword]
+   ;; TODO mixedCase shouldn't be font-locked to clojure-interop-method-face
+   [mixedCase]
+   [CamelCase]))
+
+;; examples of valid namespace definitions
+(comment
+  (ns .validns)
+  (ns =validns)
+  (ns .ValidNs=<>?+|?*.)
+  (ns ValidNs<>?+|?*.b*ar.ba*z)
+  (ns other.valid.ns)
+  (ns foo.bar))
 
 (comment ;; for indentation
   (with-hi heya


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [ ] All tests are passing (`make test`)

- Using cask for testing is a pain :-(
1. Cask installation doesn't work from behind a proxy
2. Being behind or a proxy or not - in both cases I get:
```
$ make test
make: *** No rule to make target '/home/bost/dev/clojure-mode/.cask/25.3/elpa', needed by 'test'.  Stop.
```
However `M-x spacemacs/ert-run-tests-buffer` shows no new errors (on top of those 8 existing already)

- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
- I fixed a bug. No readme change is needed.
