### PR TITLE
[Fix #451] respect project root dir suggested by custom function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#443](https://github.com/clojure-emacs/clojure-mode/issues/443): Fix behavior of `clojure-forward-logical-sexp` and `clojure-backward-logical-sexp` with conditional macros.
 * [#429](https://github.com/clojure-emacs/clojure-mode/issues/429): Fix a bug causing last occurrence of expression sometimes is not replaced when using `move-to-let`.
 * [#423](https://github.com/clojure-emacs/clojure-mode/issues/423): Make `clojure-match-next-def` more robust against zero-arity def-like forms.
+* [#451](https://github.com/clojure-emacs/clojure-mode/issues/451): Make project root directory calculation customized by `clojure-project-root-function`
 
 ### New features
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -192,7 +192,7 @@ Out-of-the box `clojure-mode' understands lein, boot and gradle."
           (and (listp value)
                (cl-every 'stringp value))))
 
-(defcustom clojure-project-root-function 'clojure-project-dir
+(defcustom clojure-project-root-function 'clojure-project-root-path
   "Function to locate clojure project root directory."
   :type 'function
   :risky t
@@ -1604,6 +1604,13 @@ nil."
 
 
 (defun clojure-project-dir (&optional dir-name)
+  "Return the absolute path to the project's root directory.
+
+Call is delegated down to `clojure-project-root-function' with
+optional DIR-NAME as argument."
+  (funcall clojure-project-root-function dir-name))
+
+(defun clojure-project-root-path (&optional dir-name)
   "Return the absolute path to the project's root directory.
 
 Use `default-directory' if DIR-NAME is nil.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1620,10 +1620,8 @@ Return nil if not inside a project."
                         (mapcar (lambda (fname)
                                   (locate-dominating-file dir-name fname))
                                 clojure-build-tool-files))))
-    (or (ignore-errors
-          (funcall clojure-project-root-function))
-        (when (> (length choices) 0)
-          (car (sort choices #'file-in-directory-p))))))
+    (when (> (length choices) 0)
+      (car (sort choices #'file-in-directory-p)))))
 
 (defun clojure-project-relative-path (path)
   "Denormalize PATH by making it relative to the project root."

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -192,6 +192,11 @@ Out-of-the box `clojure-mode' understands lein, boot and gradle."
           (and (listp value)
                (cl-every 'stringp value))))
 
+(defcustom clojure-project-root-locating-function nil
+  "Alternative function to locate clojure project root directory, eg. projectile-project-root"
+  :type 'symbol
+  :safe 'symbolp)
+
 (defcustom clojure-refactor-map-prefix (kbd "C-c C-r")
   "Clojure refactor keymap prefix."
   :type 'string
@@ -1607,9 +1612,9 @@ Return nil if not inside a project."
                         (mapcar (lambda (fname)
                                   (locate-dominating-file dir-name fname))
                                 clojure-build-tool-files))))
-    (or (and (fboundp 'projectile-project-root)
+    (or (and (fboundp clojure-project-root-locating-function)
              (condition-case err
-                 (projectile-project-root)
+                 (funcall clojure-project-root-locating-function)
                (error nil)))
         (when (> (length choices) 0)
           (car (sort choices #'file-in-directory-p))))))

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -192,10 +192,11 @@ Out-of-the box `clojure-mode' understands lein, boot and gradle."
           (and (listp value)
                (cl-every 'stringp value))))
 
-(defcustom clojure-project-root-locating-function nil
-  "Alternative function to locate clojure project root directory, eg. projectile-project-root"
-  :type 'symbol
-  :safe 'symbolp)
+(defcustom clojure-project-root-function 'clojure-project-dir
+  "Function to locate clojure project root directory."
+  :type 'function
+  :risky t
+  :package-version '(clojure-mode . "5.7.0"))
 
 (defcustom clojure-refactor-map-prefix (kbd "C-c C-r")
   "Clojure refactor keymap prefix."
@@ -1612,10 +1613,8 @@ Return nil if not inside a project."
                         (mapcar (lambda (fname)
                                   (locate-dominating-file dir-name fname))
                                 clojure-build-tool-files))))
-    (or (and (fboundp clojure-project-root-locating-function)
-             (condition-case err
-                 (funcall clojure-project-root-locating-function)
-               (error nil)))
+    (or (ignore-errors
+          (funcall clojure-project-root-function))
         (when (> (length choices) 0)
           (car (sort choices #'file-in-directory-p))))))
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1607,8 +1607,12 @@ Return nil if not inside a project."
                         (mapcar (lambda (fname)
                                   (locate-dominating-file dir-name fname))
                                 clojure-build-tool-files))))
-    (when (> (length choices) 0)
-      (car (sort choices #'file-in-directory-p)))))
+    (or (and (fboundp 'projectile-project-root)
+             (condition-case err
+                 (projectile-project-root)
+               (error nil)))
+        (when (> (length choices) 0)
+          (car (sort choices #'file-in-directory-p))))))
 
 (defun clojure-project-relative-path (path)
   "Denormalize PATH by making it relative to the project root."

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -192,7 +192,7 @@ Out-of-the box `clojure-mode' understands lein, boot and gradle."
           (and (listp value)
                (cl-every 'stringp value))))
 
-(defcustom clojure-project-root-function 'clojure-project-root-path
+(defcustom clojure-project-root-function #'clojure-project-root-path
   "Function to locate clojure project root directory."
   :type 'function
   :risky t


### PR DESCRIPTION
This is a humble attempt to get clojure-mode respecting project root directory suggested by a custom function (like projectile-project-root), as described in #451 