### PR TITLE
Try to simplify the PR template a bit - Fix #449

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,15 @@
-**Replace this placeholder text with a summary of the changes in your PR.
-The more detailed you are, the better.**
+**Replace this placeholder text with a summary of the changes in your PR.**
 
 -----------------
 
-Before submitting a PR make sure the following things have been done (and denote this
-by checking the relevant checkboxes):
+Before submitting a PR mark the checkboxes for the items you've done (if you
+think a checkbox does not apply, then leave it unchecked):
 
-- [ ] The commits are consistent with our [contribution guidelines][1]
-- [ ] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
-- [ ] All tests are passing (`make test`)
-- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
-- [ ] You've updated the changelog (if adding/changing user-visible functionality)
-- [ ] You've updated the readme (if adding/changing user-visible functionality)
+- [ ] The commits are consistent with our [contribution guidelines][1].
+- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
+- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
+- [ ] You've updated the changelog (if adding/changing user-visible functionality).
+- [ ] You've updated the readme (if adding/changing user-visible functionality).
 
 Thanks!
 


### PR DESCRIPTION
This shortens the template just a bit. 

- It removes the "make test" line. That's why we have CI, and running tests locally can indeed be quite cumbersome.
- It removes the unexplained bytecode thingy (since that's included in make tests).
- It says that writing tests is optional. We can always ask the person to write a test after they open the PR (and they're much more likely to write it at that point).

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] You've added tests (if possible) to cover your change(s). Indentation & font-lock tests are extremely important!
- [x] All tests are passing (`make test`)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
