### PR TITLE
Move to top level before `re-search-backward` in `clojure-find-ns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#458](https://github.com/clojure-emacs/clojure-mode/pull/458): Get correct ns when in middle of ns form with `clojure-find-ns`
 * [#447](https://github.com/clojure-emacs/clojure-mode/issues/241): When `electric-indent-mode` is on, force indentation from within docstrings.
 * [#438](https://github.com/clojure-emacs/clojure-mode/issues/438): Filling within a doc-string doesn't affect surrounding code. 
 * Fix fill-paragraph in multi-line comments.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1763,6 +1763,10 @@ no namespaces above point, return the first one in the buffer."
   (save-excursion
     (save-restriction
       (widen)
+
+      ;; Move to top-level to avoid searching from inside ns
+      (ignore-errors (while t (up-list nil t t)))
+
       ;; The closest ns form above point.
       (when (or (re-search-backward clojure-namespace-name-regex nil t)
                 ;; Or any form at all.

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -75,6 +75,26 @@
     (insert "(+ 10")
     (newline-and-indent)))
 
+(ert-deftest clojure-find-ns-test ()
+  (with-temp-buffer
+    (insert "(ns ^{:doc \"Some docs\"}\nfoo-bar)")
+    (newline)
+    (newline)
+    (insert "(in-ns 'baz-quux)")
+    (clojure-mode)
+
+    ;; From inside docstring of first ns
+    (goto-char 18)
+    (should (equal "foo-bar" (clojure-find-ns)))
+
+    ;; From inside first ns's name, on its own line
+    (goto-char 29)
+    (should (equal "foo-bar" (clojure-find-ns)))
+
+    ;; From inside second ns's name
+    (goto-char 42)
+    (should (equal "baz-quux" (clojure-find-ns)))))
+
 (provide 'clojure-mode-sexp-test)
 
 ;;; clojure-mode-sexp-test.el ends here


### PR DESCRIPTION
Moving to top level avoids improper matching behavior due to being in middle
of match.

Fix clojure-emacs/cider#2100