### PR TITLE
don't find namespace in Org-mode buffer for ob-clojure `cider-current…

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1761,19 +1761,20 @@ content) are considered part of the preceding sexp."
   "Return the namespace of the current Clojure buffer.
 Return the namespace closest to point and above it.  If there are
 no namespaces above point, return the first one in the buffer."
-  (save-excursion
-    (save-restriction
-      (widen)
+  (if (not (equal major-mode 'org-mode)) ; don't find namespace in Org-mode buffer for ob-clojure `cider-current-ns'.
+      (save-excursion
+        (save-restriction
+          (widen)
 
-      ;; Move to top-level to avoid searching from inside ns
-      (ignore-errors (while t (up-list nil t t)))
+          ;; Move to top-level to avoid searching from inside ns
+          (ignore-errors (while t (up-list nil t t)))
 
-      ;; The closest ns form above point.
-      (when (or (re-search-backward clojure-namespace-name-regex nil t)
-                ;; Or any form at all.
-                (and (goto-char (point-min))
-                     (re-search-forward clojure-namespace-name-regex nil t)))
-        (match-string-no-properties 4)))))
+          ;; The closest ns form above point.
+          (when (or (re-search-backward clojure-namespace-name-regex nil t)
+                    ;; Or any form at all.
+                    (and (goto-char (point-min))
+                         (re-search-forward clojure-namespace-name-regex nil t)))
+            (match-string-no-properties 4))))))
 
 (defconst clojure-def-type-and-name-regex
   (concat "(\\(?:\\(?:\\sw\\|\\s_\\)+/\\)?"


### PR DESCRIPTION
Because an org-mode file might contains multiple babel src blocks which has different Clojure namespace source code. If `clojure-find-ns` in an Org-mode will cause `ob-clojure` evaluate src block error "namespace-not-found" in cider eval respond dict.

For example:
```org
* test results output

#+BEGIN_SRC clojure :result output
(println "hi")
(println (str *ns*))
#+END_SRC

When I execute first src block [C-c C-c], it will find namespace and
return wrong namespace ~kk~ in second src block. This is not a
expected behavior.

* different namespace

#+BEGIN_SRC clojure :result output
(in-ns 'kk)
(println (str *ns*))
#+END_SRC
```
-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [X] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
