### PR TITLE
Make three font-lock faces customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Introduce `clojure-global-constant-face`, `clojure-def-symbol-face`, `clojure-lambda-arg-face`.
 * Indent `fdef` (clojure.spec) like a `def`.
 * The results of `clojure-project-dir` are cached by default to optimize performance.
 * Add `shadow-cljs.edn` to the default list of build tool files.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -92,6 +92,26 @@
   "Face used to font-lock Clojure character literals."
   :package-version '(clojure-mode . "3.0.0"))
 
+(defface clojure-interop-method-face
+  '((t (:inherit font-lock-preprocessor-face)))
+  "Face used to font-lock interop method names (camelCase)."
+  :package-version '(clojure-mode . "3.0.0"))
+
+(defface clojure-global-constant-face
+  '((t (:inherit font-lock-constant-face)))
+  "Face used to font-lock the Clojure global constants: nil, true, false."
+  :package-version '(clojure-mode . "3.0.0"))
+
+(defface clojure-def-symbol-face
+  '((t (:inherit font-lock-keyword-face)))
+  "Face used to font-lock the symbols `def`, `defn`, and all detected variants (be them from clojure.core or not)."
+  :package-version '(clojure-mode . "3.0.0"))
+
+(defface clojure-lambda-arg-face
+  '((t (:inherit font-lock-variable-name-face)))
+  "Face used to font-lock the function literal args: %, %&, %1 and so on."
+  :package-version '(clojure-mode . "3.0.0"))
+
 (defcustom clojure-indent-style :always-align
   "Indentation style to use for function forms and macro forms.
 There are two cases of interest configured by this variable.
@@ -754,7 +774,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
                 ;; Possibly type or metadata
                 "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
                 "\\(\\sw+\\)?")
-       (1 font-lock-keyword-face)
+       (1 'clojure-def-symbol-face)
        (2 font-lock-variable-name-face nil t))
       ;; Type definition
       (,(concat "(\\(?:clojure.core/\\)?\\("
@@ -767,7 +787,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
                 ;; Possibly type or metadata
                 "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
                 "\\(\\sw+\\)?")
-       (1 font-lock-keyword-face)
+       (1 'clojure-def-symbol-face)
        (2 font-lock-type-face nil t))
       ;; Function definition (anything that starts with def and is not
       ;; listed above)
@@ -780,7 +800,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
                 ;; Possibly type or metadata
                 "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
                 "\\(\\sw+\\)?")
-       (1 font-lock-keyword-face)
+       (1 'clojure-def-symbol-face)
        (2 font-lock-function-name-face nil t))
       ;; (fn name? args ...)
       (,(concat "(\\(?:clojure.core/\\)?\\(fn\\)[ \t]+"
@@ -791,7 +811,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
        (1 font-lock-keyword-face)
        (2 font-lock-function-name-face nil t))
       ;; lambda arguments - %, %&, %1, %2, etc
-      ("\\<%[&1-9]?" (0 font-lock-variable-name-face))
+      ("\\<%[&1-9]?" (0 'clojure-lambda-arg-face))
       ;; Special forms
       (,(concat
          "("
@@ -848,7 +868,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
          (regexp-opt
           '("true" "false" "nil") t)
          "\\>")
-       0 font-lock-constant-face)
+       0 'clojure-global-constant-face)
       ;; Character literals - \1, \a, \newline, \u0000
       ("\\\\\\([[:punct:]]\\|[a-z0-9]+\\>\\)" 0 'clojure-character-face)
 

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -702,49 +702,49 @@ POS."
   (clojure-test-with-temp-buffer "(_c4/defconstrainedfn bar [] nil)"
     (should (eq (clojure-test-face-at 2 4) 'font-lock-type-face))
     (should (eq (clojure-test-face-at 5 5) nil))
-    (should (eq (clojure-test-face-at 6 18) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 6 18) 'clojure-def-symbol-face))
     (should (eq (clojure-test-face-at 23 25) 'font-lock-function-name-face)))
   (clojure-test-with-temp-buffer "(clo/defbar foo nil)"
     (should (eq (clojure-test-face-at 2 4) 'font-lock-type-face))
     (should (eq (clojure-test-face-at 5 5) nil))
-    (should (eq (clojure-test-face-at 6 11) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 6 11) 'clojure-def-symbol-face))
     (should (eq (clojure-test-face-at 13 15) 'font-lock-function-name-face))))
 
 (ert-deftest clojure-mode-syntax-table/variable-def ()
   :tags '(fontification syntax-table)
   (should (eq (clojure-test-face-at 2 4 "(def foo 10)")
-              'font-lock-keyword-face))
+              'clojure-def-symbol-face))
   (should (eq (clojure-test-face-at 6 8 "(def foo 10)")
               'font-lock-variable-name-face)))
 
 (ert-deftest clojure-mode-syntax-table/type-def ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "(deftype Foo)"
-    (should (eq (clojure-test-face-at 2 8) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 2 8) 'clojure-def-symbol-face))
     (should (eq (clojure-test-face-at 10 12) 'font-lock-type-face))))
 
 (ert-deftest clojure-mode-syntax-table/function-def ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "(defn foo [x] x)"
-    (should (eq (clojure-test-face-at 2 5) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 2 5) 'clojure-def-symbol-face))
     (should (eq (clojure-test-face-at 7 9) 'font-lock-function-name-face))))
 
 (ert-deftest clojure-mode-syntax-table/custom-def-with-special-chars1 ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "(defn* foo [x] x)"
-    (should (eq (clojure-test-face-at 2 6) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 2 6) 'clojure-def-symbol-face))
     (should (eq (clojure-test-face-at 8 10) 'font-lock-function-name-face))))
 
 (ert-deftest clojure-mode-syntax-table/custom-def-with-special-chars2 ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "(defsomething! foo [x] x)"
-    (should (eq (clojure-test-face-at 2 14) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 2 14) 'clojure-def-symbol-face))
     (should (eq (clojure-test-face-at 16 18) 'font-lock-function-name-face))))
 
 (ert-deftest clojure-mode-syntax-table/custom-def-with-special-chars3 ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "(def-something foo [x] x)"
-    (should (eq (clojure-test-face-at 2 14) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 2 14) 'clojure-def-symbol-face))
     (should (eq (clojure-test-face-at 16 18) 'font-lock-function-name-face))))
 
 (ert-deftest clojure-mode-syntax-table/fn ()
@@ -758,26 +758,26 @@ POS."
 (ert-deftest clojure-mode-syntax-table/lambda-params ()
   :tags '(fontification syntax-table)
   (clojure-test-with-temp-buffer "#(+ % %2 %3 %&)"
-    (should (eq (clojure-test-face-at 5 5) 'font-lock-variable-name-face))
-    (should (eq (clojure-test-face-at 7 8) 'font-lock-variable-name-face))
-    (should (eq (clojure-test-face-at 10 11) 'font-lock-variable-name-face))
-    (should (eq (clojure-test-face-at 13 14) 'font-lock-variable-name-face))))
+    (should (eq (clojure-test-face-at 5 5) 'clojure-lambda-arg-face))
+    (should (eq (clojure-test-face-at 7 8) 'clojure-lambda-arg-face))
+    (should (eq (clojure-test-face-at 10 11) 'clojure-lambda-arg-face))
+    (should (eq (clojure-test-face-at 13 14) 'clojure-lambda-arg-face))))
 
 (ert-deftest clojure-mode-syntax-table/nil ()
   :tags '(fontification syntax-table)
-  (should (eq (clojure-test-face-at 4 6 "(= nil x)") 'font-lock-constant-face))
+  (should (eq (clojure-test-face-at 4 6 "(= nil x)") 'clojure-global-constant-face))
   (should-not (eq (clojure-test-face-at 3 5 "(fnil x)")
                   'font-lock-constant-face)))
 
 (ert-deftest clojure-mode-syntax-table/true ()
   :tags '(fontification syntax-table)
   (should (eq (clojure-test-face-at 4 7 "(= true x)")
-              'font-lock-constant-face)))
+              'clojure-global-constant-face)))
 
 (ert-deftest clojure-mode-syntax-table/false ()
   :tags '(fontification syntax-table)
   (should (eq (clojure-test-face-at 4 8 "(= false x)")
-              'font-lock-constant-face)))
+              'clojure-global-constant-face)))
 
 (ert-deftest clojure-mode-syntax-table/keyword-meta ()
   :tags '(fontification syntax-table)


### PR DESCRIPTION
Introduce `clojure-global-constant-face`, `clojure-def-symbol-face`, `clojure-lambda-arg-face`.

Updated tests, although I couldn't get to run them (never had done so. Tried with `M-x ert`):

```
Selector: t
Passed:  0
Failed:  0
Skipped: 0
Total:   0/0

Started at:   2018-01-01 07:14:57+0100
Finished.
Finished at:  2018-01-01 07:14:57+0100
```