### PR TITLE
[Fix #471] Added support for tagged maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * New interactive command `clojure-cycle-not`.
 * New defcustom `clojure-comment-regexp` for font-locking `#_` or `#_` AND `(comment)` sexps.
 * [#459](https://github.com/clojure-emacs/clojure-mode/issues/459): Add font-locking for new built-ins added in Clojure 1.9.
+* [#471](https://github.com/clojure-emacs/clojure-mode/issues/471): Support tagged maps (new in Clojure 1.9) in paredit integration.
 * Consider `deps.edn` a project root.
 
 ### Changes

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -435,6 +435,10 @@ ENDP and DELIM."
                nil)
               (t)))))
 
+(defconst clojure--collection-tag-regexp "#\\(::[a-zA-Z0-9._-]*\\|:?\\([a-zA-Z0-9._-]+/\\)?[a-zA-Z0-9._-]+\\)"
+    "Allowed strings that can come before a collection literal (e.g. '[]' or '{}'), as reader macro tags.
+This includes #fully.qualified/my-ns[:kw val] and #::my-ns{:kw val} as of Clojure 1.9.")
+
 (defun clojure-no-space-after-tag (endp delimiter)
   "Prevent inserting a space after a reader-literal tag?
 
@@ -443,8 +447,8 @@ listed in `clojure-omit-space-between-tag-and-delimiters', this
 function returns t.
 
 This allows you to write things like #db/id[:db.part/user]
-without inserting a space between the tag and the opening
-bracket.
+and #::my-ns{:some \"map\"} without inserting a space between
+the tag and the opening bracket.
 
 See `paredit-space-for-delimiter-predicates' for the meaning of
 ENDP and DELIMITER."
@@ -454,7 +458,7 @@ ENDP and DELIMITER."
         (save-excursion
           (let ((orig-point (point)))
             (not (and (re-search-backward
-                       "#\\([a-zA-Z0-9._-]+/\\)?[a-zA-Z0-9._-]+"
+                       clojure--collection-tag-regexp
                        (line-beginning-position)
                        t)
                       (= orig-point (match-end 0)))))))))

--- a/test/clojure-mode-syntax-test.el
+++ b/test/clojure-mode-syntax-test.el
@@ -78,6 +78,20 @@
       (backward-prefix-chars)
       (should (bobp)))))
 
+
+(ert-deftest clojure-allowed-collection-tags ()
+  (dolist (tag '("#::ns" "#:ns" "#ns" "#:f.q/ns" "#f.q/ns" "#::"))
+    (with-temp-buffer
+      (clojure-mode)
+      (insert tag)
+      (should-not (clojure-no-space-after-tag nil ?{))))
+  (dolist (tag '("#$:" "#/f" "#:/f" "#::f.q/ns" "::ns" "::" "#f:ns"))
+    (with-temp-buffer
+      (clojure-mode)
+      (insert tag)
+      (should (clojure-no-space-after-tag nil ?{)))))
+
+
 (def-refactor-test test-paragraph-fill-within-comments
     "
 ;; Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt


### PR DESCRIPTION
Updated `clojure-no-space-after-tag` to support tagged maps with autoresolved namespaces, such as `#::{:foo "bar"}` and `#::my-ns{:foo "bar"}`.  This is new reader syntax added in Clojure 1.9
-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [ x] The commits are consistent with our [contribution guidelines][1].
- [ x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
