### PR TITLE
Indent clojure.spec/fdef differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Indent `fdef` (clojure.spec) like a `def`.
+
 ## 5.7.0 (2018-04-29)
 
 ### New features

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1515,6 +1515,7 @@ work).  To set it from Lisp code, use
   (locking 1)
   (proxy '(2 nil nil (:defn)))
   (as-> 2)
+  (fdef 1)
 
   (reify '(:defn (1)))
   (deftype '(2 nil nil (:defn)))


### PR DESCRIPTION
```clj
;; before
(s/fdef ::uhhuh
        :args (s/keys :req [::hello])
        :ret any?)
;; after
(s/fdef ::uhhuh
  :args (s/keys :req [::hello])
  :ret any?)
```

**Replace this placeholder text with a summary of the changes in your PR.**

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [ ] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
