### PR TITLE
Add shadow-cljs.edn to the default clojure build tool files list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Indent `fdef` (clojure.spec) like a `def`.
 * The results of `clojure-project-dir` are cached by default to optimize performance.
+* Add `shadow-cljs.edn` to the default list of build tool files.
 
 ## 5.7.0 (2018-04-29)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -178,10 +178,10 @@ For example, \[ is allowed in :db/id[:db.part/user]."
           (and (listp value)
                (cl-every 'characterp value))))
 
-(defcustom clojure-build-tool-files '("project.clj" "build.boot" "build.gradle" "deps.edn")
+(defcustom clojure-build-tool-files '("project.clj" "build.boot" "build.gradle" "deps.edn" "shadow-cljs.edn")
   "A list of files, which identify a Clojure project's root.
-Out-of-the box `clojure-mode' understands lein, boot, gradle
-and tools.deps."
+Out-of-the box `clojure-mode' understands lein, boot, gradle,
+ shadow-cljs and tools.deps."
   :type '(repeat string)
   :package-version '(clojure-mode . "5.0.0")
   :safe (lambda (value)


### PR DESCRIPTION
Cider now supports shadow-cljs builds, this commit adds it's build file (shadow-cljs.edn) to the default list of build tool files so that ```clojure-project-dir``` works as expected for these projects without additional configuration.
