### PR TITLE
Fix project.el integration by introducing `clojure-project-find-function`

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -555,7 +555,7 @@ replacement for `cljr-expand-let`."
   (add-hook 'electric-indent-functions
             (lambda (_char) (if (clojure-in-docstring-p) 'do-indent)))
   ;; integration with project.el
-  (add-hook 'project-find-functions #'clojure-project-dir))
+  (add-hook 'project-find-functions #'clojure-find-function))
 
 (defcustom clojure-verify-major-mode t
   "If non-nil, warn when activating the wrong `major-mode'."
@@ -1677,6 +1677,10 @@ Return nil if not inside a project."
                                 clojure-build-tool-files))))
     (when (> (length choices) 0)
       (car (sort choices #'file-in-directory-p)))))
+
+(defun clojure-project-find-function (dir)
+  "Based on DIR return cons for use in `project-find-functions'."
+  (cons 'clojure (clojure-project-root-path dir)))
 
 (defun clojure-project-relative-path (path)
   "Denormalize PATH by making it relative to the project root."


### PR DESCRIPTION
Current CIDER (20180628.628) + clojure-mode (master) is broken for me. Sesman can't find the associated context for the repl and buffers because the return values are not as expected.

This was also discussed in this commit:
https://github.com/clojure-emacs/clojure-mode/commit/9e28721e5ed2936897f0747dcc0812f58a6fb329

Either reverting the project.el integration or adding a function that returns a cons as discussed above resolves this.

Stacktrace if needed:
```
Debugger entered--Lisp error: (wrong-type-argument listp "/home/benny/Projects/Clojure/porter/")
  cdr("/home/benny/Projects/Clojure/porter/")
  (concat "^" (cdr proj))
  (string-match-p (concat "^" (cdr proj)) (expand-file-name default-directory))
  (progn (string-match-p (concat "^" (cdr proj)) (expand-file-name default-directory)))
  (if (and proj default-directory) (progn (string-match-p (concat "^" (cdr proj)) (expand-file-name default-directory))))
  (progn (if (and proj default-directory) (progn (string-match-p (concat "^" (cdr proj)) (expand-file-name default-directory)))))
  (closure (t) (_cxt-type proj) "Non-nil if PROJ is the parent or equals the `default-directory'." (progn (if (and proj default-directory) (progn (string-match-p (concat "^" (cdr proj)) (expand-file-name default-directory))))))(project "/home/benny/Projects/Clojure/porter/")
  apply((closure (t) (_cxt-type proj) "Non-nil if PROJ is the parent or equals the `default-directory'." (progn (if (and proj default-directory) (progn (string-match-p (concat "^" (cdr proj)) (expand-file-name default-directory)))))) project "/home/benny/Projects/Clojure/porter/")
  sesman-relevant-context-p(project "/home/benny/Projects/Clojure/porter/")
  (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l)))
  (closure ((lfn closure ((cxt-val) (cxt-type . project) (ses-name) (system . CIDER) (x) (cxt-val) (cxt-type . project) (ses-name) (system . CIDER) t) (el) (and (or (null system) (eq (car (car el)) system)) (or (null ses-name) (equal (cdr (car el)) ses-name)) (or (null cxt-type) (if (listp cxt-type) (member (nth 1 el) cxt-type) (eq (nth 1 el) cxt-type))) (or (null cxt-val) (equal (nth 2 el) cxt-val)))) (cxt-type . project) (cxt-types buffer directory project) (system . CIDER) t) (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))(((CIDER . "porter") project "/home/benny/Projects/Clojure/porter/"))
  #f(compiled-function (elt) #<bytecode 0x1985995>)(((CIDER . "porter") project "/home/benny/Projects/Clojure/porter/"))
  mapcar(#f(compiled-function (elt) #<bytecode 0x1985995>) (((CIDER . "porter") project "/home/benny/Projects/Clojure/porter/")))
  #f(compiled-function (function sequence) #<bytecode 0x1ec08ad>)(#f(compiled-function (elt) #<bytecode 0x1985995>) (((CIDER . "porter") project "/home/benny/Projects/Clojure/porter/")))
  apply(#f(compiled-function (function sequence) #<bytecode 0x1ec08ad>) #f(compiled-function (elt) #<bytecode 0x1985995>) (((CIDER . "porter") project "/home/benny/Projects/Clojure/porter/")) nil)
  seq-map(#f(compiled-function (elt) #<bytecode 0x1985995>) (((CIDER . "porter") project "/home/benny/Projects/Clojure/porter/")))
  seq-filter((closure ((lfn closure ((cxt-val) (cxt-type . project) (ses-name) (system . CIDER) (x) (cxt-val) (cxt-type . project) (ses-name) (system . CIDER) t) (el) (and (or (null system) (eq (car (car el)) system)) (or (null ses-name) (equal (cdr (car el)) ses-name)) (or (null cxt-type) (if (listp cxt-type) (member (nth 1 el) cxt-type) (eq (nth 1 el) cxt-type))) (or (null cxt-val) (equal (nth 2 el) cxt-val)))) (cxt-type . project) (cxt-types buffer directory project) (system . CIDER) t) (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l)))) (((CIDER . "porter") project "/home/benny/Projects/Clojure/porter/")))
  (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist))
  (let ((lfn (sesman--link-lookup-fn system nil cxt-type))) (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist)))
  (closure ((cxt-types buffer directory project) (system . CIDER) t) (cxt-type) (let ((lfn (sesman--link-lookup-fn system nil cxt-type))) (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist))))(project)
  mapcar((closure ((cxt-types buffer directory project) (system . CIDER) t) (cxt-type) (let ((lfn (sesman--link-lookup-fn system nil cxt-type))) (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist)))) (buffer directory project))
  #f(compiled-function (function sequence) #<bytecode 0x1ec08ad>)((closure ((cxt-types buffer directory project) (system . CIDER) t) (cxt-type) (let ((lfn (sesman--link-lookup-fn system nil cxt-type))) (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist)))) (buffer directory project))
  apply(#f(compiled-function (function sequence) #<bytecode 0x1ec08ad>) (closure ((cxt-types buffer directory project) (system . CIDER) t) (cxt-type) (let ((lfn (sesman--link-lookup-fn system nil cxt-type))) (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist)))) (buffer directory project) nil)
  seq-map((closure ((cxt-types buffer directory project) (system . CIDER) t) (cxt-type) (let ((lfn (sesman--link-lookup-fn system nil cxt-type))) (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist)))) (buffer directory project))
  seq-mapcat((closure ((cxt-types buffer directory project) (system . CIDER) t) (cxt-type) (let ((lfn (sesman--link-lookup-fn system nil cxt-type))) (sesman--sort-links system (seq-filter (function (lambda (l) (and (funcall lfn l) (sesman-relevant-context-p cxt-type (nth 2 l))))) sesman-links-alist)))) (buffer directory project))
  sesman-current-links(CIDER (buffer directory project))
  (mapcar (function (lambda (assoc) (gethash (car assoc) sesman-sessions-hashmap))) (sesman-current-links system cxt-types))
  (let* ((system (or system (sesman--system))) (cxt-types (or cxt-types (sesman-context-types system)))) (sesman--clear-links) (mapcar (function (lambda (assoc) (gethash (car assoc) sesman-sessions-hashmap))) (sesman-current-links system cxt-types)))
  sesman-linked-sessions(CIDER nil)
  (car (sesman-linked-sessions system cxt-types))
  sesman-current-session(CIDER)
  (cdr (sesman-current-session 'CIDER))
  (let ((repls (cdr (sesman-current-session 'CIDER)))) (if (or (null type) (equal type "multi")) repls (seq-filter (function (lambda (b) (string= type (cider-repl-type b)))) repls)))
  cider-repls("clj")
  (let* ((type (or type (cider-repl-type-for-buffer))) (repls (cider-repls type))) (seq-find (function (lambda (b) (member b repls))) (buffer-list)))
  (if (and (derived-mode-p 'cider-repl-mode) (or (null type) (string= cider-repl-type type))) (current-buffer) (let* ((type (or type (cider-repl-type-for-buffer))) (repls (cider-repls type))) (seq-find (function (lambda (b) (member b repls))) (buffer-list))))
  cider-current-repl()
  (and t (cider-current-repl))
  (let* ((conn (and t (cider-current-repl)))) (if conn (save-current-buffer (set-buffer conn) (nrepl-dict-get-in cider-repl-ns-cache keys))))
```
-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
