### PR TITLE
Make `beginning-of-defun` aware of clojure comment form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `clojure-toplevel-inside-comment-form` to make forms inside of `(comment ...)` forms appear as top level forms for evaluation and navigation.
 * Require Emacs 25.1+.
 
 ## 5.8.2 (2018-08-09)

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -22,6 +22,51 @@
 (require 'clojure-mode)
 (require 'ert)
 
+(defmacro clojure-buffer-with-text (text &rest body)
+  "Run body in a temporary clojure buffer with TEXT.
+TEXT is a string with a | indicating where point is. The | will be erased
+and point left there."
+  (declare (indent 2))
+  `(progn
+     (with-temp-buffer
+       (erase-buffer)
+       (clojure-mode)
+       (insert ,text)
+       (goto-char (point-min))
+       (re-search-forward "|")
+       (delete-char -1)
+       ,@body)))
+
+(ert-deftest test-clojure-top-level-form-p ()
+  (clojure-buffer-with-text
+      "(comment
+         (wrong)
+         (rig|ht)
+         (wrong))"
+      ;; make this use the native beginning of defun since this is used to
+      ;; determine whether to use the comment aware version or not.
+      (should (let ((beginning-of-defun-function nil))
+                (clojure-top-level-form-p "comment")))))
+
+(ert-deftest test-clojure-beginning-of-defun-function ()
+  (clojure-buffer-with-text
+      "(comment
+          (wrong)
+          (wrong)
+          (rig|ht)
+          (wrong))"
+      (beginning-of-defun)
+    (should (looking-at-p "(comment")))
+  (clojure-buffer-with-text
+      "(comment
+          (wrong)
+          (wrong)
+          (rig|ht)
+          (wrong))"
+      (let ((clojure-toplevel-inside-comment-form t))
+       (beginning-of-defun))
+    (should (looking-at-p "(right)"))))
+
 (ert-deftest test-sexp-with-commas ()
   (with-temp-buffer
     (insert "[], {}, :a, 2")


### PR DESCRIPTION
Moves the notion of top level inside of a comment form into `clojure-mode`. Makes the necessary change such that `beginning-of-defun` is aware of this and thus CIDER can use it transparently.

Added tests and changelog. Wasn't sure if this should be in README. 

Next step will be to pull this change out of CIDER once this is accepted.

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).