### PR TITLE
Fix bug in end-of-defun

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1955,7 +1955,8 @@ This will skip over sexps that don't represent objects, so that ^hints and
         (clojure-forward-logical-sexp 1)
         (clojure-backward-logical-sexp 1)
         (looking-at-p first-form))
-    (scan-error nil)))
+    (scan-error nil)
+    (end-of-buffer nil)))
 
 (defun clojure-sexp-starts-until-position (position)
   "Return the starting points for forms before POSITION.
@@ -1992,10 +1993,11 @@ testing, give an easy way to turn this new behavior off."
         (setq haystack (cdr haystack))))
     found))
 
-(defun clojure-beginning-of-defun-function ()
+(defun clojure-beginning-of-defun-function (&optional n)
   "Go to top level form.
 Set as `beginning-of-defun-function' so that these generic
-operators can be used."
+operators can be used.  Given a positive N it will do it that
+many times."
   (let ((beginning-of-defun-function nil))
     (if (and clojure-toplevel-inside-comment-form
              (clojure-top-level-form-p "comment"))
@@ -2013,8 +2015,8 @@ operators can be used."
                                                      (clojure-sexp-starts-until-position
                                                       clojure-comment-end))))
                 (progn (goto-char sexp-start) t)
-              (progn (beginning-of-defun) t))))
-      (progn (beginning-of-defun) t))))
+              (beginning-of-defun n))))
+      (beginning-of-defun n))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -65,7 +65,21 @@ and point left there."
           (wrong))"
       (let ((clojure-toplevel-inside-comment-form t))
        (beginning-of-defun))
-    (should (looking-at-p "(right)"))))
+    (should (looking-at-p "[[:space:]]*(right)"))))
+
+(ert-deftest test-clojure-end-of-defun-function ()
+  (clojure-buffer-with-text
+      "
+(first form)
+|
+(second form)
+
+(third form)"
+      
+      (end-of-defun)
+    (backward-char)
+    (should (looking-back "(second form)"))))
+
 
 (ert-deftest test-sexp-with-commas ()
   (with-temp-buffer


### PR DESCRIPTION
Going to end of defun would skip over two forms. Needed to pass on the negative
prefix that was used by the generic parts of this mechanism.

Also fixed an issue with paredit would not insert parens in an empty
buffer by handling the `end-of-buffer` condition.

**Replace this placeholder text with a summary of the changes in your PR.**
