### PR TITLE
Introduce `clojure-align-separator` defcustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#481](https://github.com/clojure-emacs/clojure-mode/issues/481): Support vertical alignment even in the presence of blank lines, with the new `clojure-align-separator` user option.
 * [#483](https://github.com/clojure-emacs/clojure-mode/issues/483): Support alignment for reader conditionals, with the new `clojure-align-reader-conditionals` user option.
 
 ## 5.9.1 (2018-08-27)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1090,6 +1090,16 @@ will align the values like this:
   :safe #'booleanp
   :type 'boolean)
 
+(defconst clojure--align-separator-newline-regexp "^ *$")
+
+(defcustom clojure-align-separator clojure--align-separator-newline-regexp
+  "The separator that will be passed to `align-region' when performing verical alignment."
+  :package-version '(clojure-mode . "5.10")
+  :type `(choice (const :tag "Make blank lines prevent vertical alignment from happening."
+                        ,clojure--align-separator-newline-regexp)
+                 (other :tag "Allow blank lines to happen within a vertically-aligned expression."
+                        'entire)))
+
 (defcustom clojure-align-reader-conditionals nil
   "Whether to align reader conditionals, as if they were maps."
   :package-version '(clojure-mode . "5.10")
@@ -1235,9 +1245,9 @@ When called from lisp code align everything between BEG and END."
             (cl-incf count)))
         (dotimes (_ count)
           (align-region (point) sexp-end nil
-                        '((clojure-align (regexp . clojure--search-whitespace-after-next-sexp)
+                        `((clojure-align (regexp . clojure--search-whitespace-after-next-sexp)
                                          (group . 1)
-                                         (separate . "^ *$")
+                                         (separate . ,clojure-align-separator)
                                          (repeat . t)))
                         nil))
         ;; Reindent after aligning because of #360.


### PR DESCRIPTION
Fixes #481 

I'm not sure I used the `type '(choice (const ...` syntax correctly, since when I changed it using the value menu in `M-x customize variable`, the value of `clojure-align-separator` would appear unchanged  (even though the widget says otherwise).