### PR TITLE
[Fix 489] Inserting parens before comment form doesn't move point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#483](https://github.com/clojure-emacs/clojure-mode/issues/483): Support alignment for reader conditionals, with the new `clojure-align-reader-conditionals` user option.
 
+### Bugs fixed
+
+* [#489](https://github.com/clojure-emacs/clojure-mode/issues/489) Inserting parens before comment form doesn't move point
+
 ## 5.9.1 (2018-08-27)
 
 * [#485](https://github.com/clojure-emacs/clojure-mode/issues/485): Fix a regression in `end-f-defun`.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1967,8 +1967,7 @@ This will skip over sexps that don't represent objects, so that ^hints and
   "Return truthy if the first form matches FIRST-FORM."
   (condition-case nil
       (save-excursion
-        (end-of-defun)
-        (clojure-backward-logical-sexp 1)
+        (beginning-of-defun)
         (forward-char 1)
         (clojure-forward-logical-sexp 1)
         (clojure-backward-logical-sexp 1)
@@ -2022,10 +2021,11 @@ many times."
         (save-match-data
           (let ((original-position (point))
                 clojure-comment-start clojure-comment-end)
+            (beginning-of-defun)
+            (setq clojure-comment-start (point))
             (end-of-defun)
             (setq clojure-comment-end (point))
-            (clojure-backward-logical-sexp 1) ;; beginning of comment form
-            (setq clojure-comment-start (point))
+            (beginning-of-defun)
             (forward-char 1)              ;; skip paren so we start at comment
             (clojure-forward-logical-sexp) ;; skip past the comment form itself
             (if-let ((sexp-start (clojure-find-first (lambda (beg-pos)

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -65,7 +65,15 @@ and point left there."
           (wrong))"
       (let ((clojure-toplevel-inside-comment-form t))
        (beginning-of-defun))
-    (should (looking-at-p "[[:space:]]*(right)"))))
+      (should (looking-at-p "[[:space:]]*(right)")))
+  (clojure-buffer-with-text
+   "
+(formA)
+|
+(formB)"
+   (let ((clojure-toplevel-inside-comment-form t))
+     (beginning-of-defun)
+     (should (looking-at-p "(formA)")))))
 
 (ert-deftest test-clojure-end-of-defun-function ()
   (clojure-buffer-with-text


### PR DESCRIPTION
https://github.com/clojure-emacs/clojure-mode/issues/489

In a form like

|

(comment
   (stuff))

Entering parens with paredit would put the parens right before the comment
block. Paredit determines if it is in a comment to insert parens so it doesn't
automatically enter a closing when in a comment or a string. Part of this called
beginning-of-defun which we have modified.

The error here was that rater than just going to the beginning of the form, we
went to the end and then back one logical form to be at the beginning. This is
identical behavior _unless_ you are between two forms. Going straight to the
beginning put you in the first form, going to the end and then the beginning
puts you in the second form. I.e.,

(formA)
|
(formB)

Our beginning of form went to formB but it should go to formA.

**Replace this placeholder text with a summary of the changes in your PR.**

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
