### PR TITLE
Fix typo

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1488,7 +1488,7 @@ This function also returns nil meaning don't specify the indentation."
             ;; Preserve useful alignment of :require (and friends) in `ns' forms.
             ((and function (string-match "^:" function))
              (clojure--normal-indent last-sexp :always-align))
-            ;; This is should be identical to the :defn above.
+            ;; This should be identical to the :defn above.
             ((and function
                   (string-match "\\`\\(?:\\S +/\\)?\\(def[a-z]*\\|with-\\)"
                                 function)


### PR DESCRIPTION
This is a typo fix in a comment, it should not affect the behaviour of clojure-mode. It's a small thanks for creating this mode!

I ran this using emacs version 26.0.50.3 on OSX El Capitan, the clojure-mode version is shown as 5.8.2. I don't believe there are any other tasks to take care of as described in the contribution guidelines.