### PR TITLE
Handle unbalanced parens in custom beginning of defun fn

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2028,22 +2028,24 @@ many times."
   (let ((beginning-of-defun-function nil))
     (if (and clojure-toplevel-inside-comment-form
              (clojure-top-level-form-p "comment"))
-        (save-match-data
-          (let ((original-position (point))
-                clojure-comment-start clojure-comment-end)
-            (beginning-of-defun)
-            (setq clojure-comment-start (point))
-            (end-of-defun)
-            (setq clojure-comment-end (point))
-            (beginning-of-defun)
-            (forward-char 1)              ;; skip paren so we start at comment
-            (clojure-forward-logical-sexp) ;; skip past the comment form itself
-            (if-let ((sexp-start (clojure-find-first (lambda (beg-pos)
-                                                       (< beg-pos original-position))
-                                                     (clojure-sexp-starts-until-position
-                                                      clojure-comment-end))))
-                (progn (goto-char sexp-start) t)
-              (beginning-of-defun n))))
+        (condition-case nil
+            (save-match-data
+              (let ((original-position (point))
+                    clojure-comment-start clojure-comment-end)
+                (beginning-of-defun)
+                (setq clojure-comment-start (point))
+                (end-of-defun)
+                (setq clojure-comment-end (point))
+                (beginning-of-defun)
+                (forward-char 1)              ;; skip paren so we start at comment
+                (clojure-forward-logical-sexp) ;; skip past the comment form itself
+                (if-let ((sexp-start (clojure-find-first (lambda (beg-pos)
+                                                           (< beg-pos original-position))
+                                                         (clojure-sexp-starts-until-position
+                                                          clojure-comment-end))))
+                    (progn (goto-char sexp-start) t)
+                  (beginning-of-defun n))))
+          (scan-error (beginning-of-defun n)))
       (beginning-of-defun n))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Paredit has some strange logic. It inserts its opening "(" and then tasks itself
with discovering whether it is in a comment or string before inserting its
closing ")". But this means that paredit _by design_ calls functions on
unbalanced parens states and I don't know why they do this.

If we find a scan-error, this bails and lets the default beginning of defun
function shoulder that logic.

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!
