### PR TITLE
Fix font-lock of type hints

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -439,7 +439,7 @@ ENDP and DELIM."
               (t)))))
 
 (defconst clojure--collection-tag-regexp "#\\(::[a-zA-Z0-9._-]*\\|:?\\([a-zA-Z0-9._-]+/\\)?[a-zA-Z0-9._-]+\\)"
-    "Collection reader macro tag regexp.
+  "Collection reader macro tag regexp.
 It is intended to check for allowed strings that can come before a
 collection literal (e.g. '[]' or '{}'), as reader macro tags.
 This includes #fully.qualified/my-ns[:kw val] and #::my-ns{:kw
@@ -880,12 +880,12 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
        (2 'clojure-keyword-face))
 
       ;; type-hints: #^oneword
-      (,(concat "\\(#^\\)\\(" clojure--sym-regexp "?\\)\\(/\\)\\(" clojure--sym-regexp "\\)")
+      (,(concat "\\(#?\\^\\)\\(" clojure--sym-regexp "?\\)\\(/\\)\\(" clojure--sym-regexp "\\)")
        (1 'default)
        (2 font-lock-type-face)
        (3 'default)
        (4 'default))
-      (,(concat "\\(#^\\)\\(" clojure--sym-regexp "\\)")
+      (,(concat "\\(#?\\^\\)\\(" clojure--sym-regexp "\\)")
        (1 'default)
        (2 font-lock-type-face))
 

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -347,9 +347,10 @@ POS."
 
   ;; type-hint
   (should (eq (clojure-test-face-at 1 2     "#^ve/yCom|pLex.stu-ff") 'default))
-  (should (eq (clojure-test-face-at 3 4     "#^ve/yCom|pLex.stu-ff")
-              'font-lock-type-face))
+  (should (eq (clojure-test-face-at 3 4     "#^ve/yCom|pLex.stu-ff") 'font-lock-type-face))
   (should (eq (clojure-test-face-at 5 21    "#^ve/yCom|pLex.stu-ff") 'default))
+  (should (eq (clojure-test-face-at 2 3     "^ve/yCom|pLex.stu-ff") 'font-lock-type-face))
+  (should (eq (clojure-test-face-at 5 20    "^ve/yCom|pLex.stu-ff") 'default))
 
   (should (eq (clojure-test-face-at 3 4     " (ve/yCom|pLex.stu-ff)")
               'font-lock-type-face))


### PR DESCRIPTION
Currently type hints are matched as starting with `#^foo` but I think most users use the plain `^boo`. I personally didn't even know that type hinting can be done with `#^`. 