### PR TITLE
Indent "let", "when" and "while" as function form if not at start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [#481](https://github.com/clojure-emacs/clojure-mode/issues/481): Support vertical alignment even in the presence of blank lines, with the new `clojure-align-separator` user option.
 * [#483](https://github.com/clojure-emacs/clojure-mode/issues/483): Support alignment for reader conditionals, with the new `clojure-align-reader-conditionals` user option.
-- Indent "let", "when" and "while" as function form if not at start of a symbol
+* [#497](https://github.com/clojure-emacs/clojure-mode/pull/497) Indent "let", "when" and "while" as function form if not at start of a symbol
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#481](https://github.com/clojure-emacs/clojure-mode/issues/481): Support vertical alignment even in the presence of blank lines, with the new `clojure-align-separator` user option.
 * [#483](https://github.com/clojure-emacs/clojure-mode/issues/483): Support alignment for reader conditionals, with the new `clojure-align-reader-conditionals` user option.
+- Indent "let", "when" and "while" as function form if not at start of a symbol
 
 ### Bugs fixed
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1304,7 +1304,10 @@ symbol properties."
                  'clojure-indent-function)
             (get (intern-soft (match-string 1 function-name))
                  'clojure-backtracking-indent)))
-      (when (string-match (rx string-start (or "let" "when" "while" "if") (syntax symbol))
+      ;; indent symbols starting if, when, ...
+      ;; such as if-let, when-let, ...
+      ;; like if, when, ...
+      (when (string-match (rx string-start (or "if" "when" "let" "while") (syntax symbol))
                           function-name)
         (clojure--get-indent-method (substring (match-string 0 function-name) 0 -1)))))
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1304,7 +1304,7 @@ symbol properties."
                  'clojure-indent-function)
             (get (intern-soft (match-string 1 function-name))
                  'clojure-backtracking-indent)))
-      (when (string-match (rx (or "let" "when" "while") (syntax symbol))
+      (when (string-match (rx string-start (or "let" "when" "while") (syntax symbol))
                           function-name)
         (clojure--get-indent-method (substring (match-string 0 function-name) 0 -1)))))
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1304,7 +1304,7 @@ symbol properties."
                  'clojure-indent-function)
             (get (intern-soft (match-string 1 function-name))
                  'clojure-backtracking-indent)))
-      (when (string-match (rx string-start (or "let" "when" "while") (syntax symbol))
+      (when (string-match (rx string-start (or "let" "when" "while" "if") (syntax symbol))
                           function-name)
         (clojure--get-indent-method (substring (match-string 0 function-name) 0 -1)))))
 

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -422,6 +422,7 @@ values of customisable variables."
   "(let-alist [x 1]\n  ())"
   "(while-alist [x 1]\n  ())"
   "(when-alist [x 1]\n  ())"
+  "(if-alist [x 1]\n  ())"
   "(indents-like-fn-when-let-while-are-not-the-start [x 1]\n                                                  ())")
 
 (defun indent-cond (indent-point state)

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -423,7 +423,7 @@ values of customisable variables."
   "(while-alist [x 1]\n  ())"
   "(when-alist [x 1]\n  ())"
   "(if-alist [x 1]\n  ())"
-  "(indents-like-fn-when-let-while-are-not-the-start [x 1]\n                                                  ())")
+  "(indents-like-fn-when-let-while-if-are-not-the-start [x 1]\n                                                     ())")
 
 (defun indent-cond (indent-point state)
   (goto-char (elt state 1))

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -421,7 +421,8 @@ values of customisable variables."
 (def-full-indent-test let-when-while-forms
   "(let-alist [x 1]\n  ())"
   "(while-alist [x 1]\n  ())"
-  "(when-alist [x 1]\n  ())")
+  "(when-alist [x 1]\n  ())"
+  "(indents-like-fn-when-let-while-are-not-the-start [x 1]\n                                                  ())")
 
 (defun indent-cond (indent-point state)
   (goto-char (elt state 1))


### PR DESCRIPTION
"let", "when" and "while" are considered to be a macro form normally:
```
(when foo
  bar)
```
Also you can introduce macros that start with "let", "when" or "while" that
will be indented like macro forms:
```
(when-foo-bar
  1
  2
  3)
```
But when "let", "when" and "while" are not in the beginning of a symbol they are
now threated as function forms:
```
(foo-when-bar 1
              2
              3)
```
-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
