### PR TITLE
Support Kotlin DSL for Gradle Projects.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -180,11 +180,12 @@ For example, \[ is allowed in :db/id[:db.part/user]."
                (cl-every 'characterp value))))
 
 (defcustom clojure-build-tool-files
-  '("project.clj"     ; Leiningen
-    "build.boot"      ; Boot
-    "build.gradle"    ; Gradle
-    "deps.edn"        ; Clojure CLI (a.k.a. tools.deps)
-    "shadow-cljs.edn" ; shadow-cljs
+  '("project.clj"      ; Leiningen
+    "build.boot"       ; Boot
+    "build.gradle"     ; Gradle
+    "build.gradle.kts" ; Gradle
+    "deps.edn"         ; Clojure CLI (a.k.a. tools.deps)
+    "shadow-cljs.edn"  ; shadow-cljs
     )
   "A list of files, which identify a Clojure project's root.
 Out-of-the box `clojure-mode' understands lein, boot, gradle,


### PR DESCRIPTION
With [Gradle 5.0](https://docs.gradle.org/5.0/release-notes.html), the Kotlin DSL left beta status. Projects making use of this DSL have build scripts named `build.gradle.kts`

It is necessary to recognize these files as Gradle projects to allow for running REPLS, tests, etc. from Gradle projects making use of this alternative build scripts.