### PR TITLE
Fix Makefile so that we can compile again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # Emacs byte-compiled files
 *.elc
 .cask
+elpa*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changes
 
 * Change the accepted values of `clojure-indent-style` from keywords to symbols.
+* [#503](https://github.com/clojure-emacs/clojure-mode/pull/503): Fix Makefile so that we can compile again.
 
 ## 5.9.1 (2018-08-27)
 

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,23 @@ PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 SRCS = $(wildcard *.el)
 OBJS = $(SRCS:.el=.elc)
 
-.PHONY: compile test clean
+.PHONY: compile test clean elpa
 
-elpa:
+all: compile
+
+elpa-$(EMACS):
 	$(CASK) install
 	$(CASK) update
 	touch $@
 
-compile: $(OBJS)
+elpa: elpa-$(EMACS)
+
+elpaclean:
+	rm -f elpa*
+	rm -rf .cask # Clean packages installed for development
+
+compile: elpa
+	$(CASK) build
 
 clean:
 	rm -f $(OBJS)


### PR DESCRIPTION
The functionality has been ported from cider, we can now use the make command
to install elpa packages and compile. This is still not perfect because in
theory we should not install things from elpa if we have them in our Emacs but
it would take more work for achieving that.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [X] The commits are consistent with our [contribution guidelines][1].
- [X] You've updated the changelog (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md