### PR TITLE
[Fix #506] fix clojure-mode-display-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * Dynamic vars whose names contain non-alphanumeric characters are now font-locked correctly.
+* [#506](https://github.com/clojure-emacs/clojure-mode/issues/506): `clojure-mode-display-version` correctly displays the package's version
 
 ## 5.10.0 (2019-01-05)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -81,7 +81,10 @@
   :link '(url-link :tag "GitHub" "https://github.com/clojure-emacs/clojure-mode")
   :link '(emacs-commentary-link :tag "Commentary" "clojure-mode"))
 
-(defconst clojure-mode-version (lm-version)
+(defconst clojure-mode-version
+  (let ((thisbuffer (or load-file-name buffer-file-name)))
+    (with-temp-buffer (insert-file-contents thisbuffer)
+                      (lm-version)))
   "The current version of `clojure-mode'.")
 
 (defface clojure-keyword-face

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -26,6 +26,10 @@
 (require 'cl-lib)
 (require 'ert)
 
+
+(ert-deftest clojure-mode-version-should-be-non-nil ()
+  (should (not (eq clojure-mode-version nil))))
+
 (let ((project-dir "/home/user/projects/my-project/")
       (clj-file-path "/home/user/projects/my-project/src/clj/my_project/my_ns/my_file.clj")
       (project-relative-clj-file-path "src/clj/my_project/my_ns/my_file.clj")


### PR DESCRIPTION
`lm-version` was returning nil, since it tried to look at the buffer headers to get the version, but it couldn't during load. I gave the contents of `clojure-mode.el`, in a temporary buffer to (lm-version) so it can read it.

Perhaps all the contents of `clojure-mode.el` should not be copied over to the temporary buffer. Should this buffer contain only part of it (only the file headers for example) ?


---
- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).