### PR TITLE
[Fix comment in #445] Proper font lock in (s/def ::keyword)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * Dynamic vars whose names contain non-alphanumeric characters are now font-locked correctly.
+* [#445 (comment)](https://github.com/clojure-emacs/clojure-mode/issues/445#issuecomment-340460753): Proper font lock for namespaced keywords like for example `(s/def ::keyword)`
 
 ## 5.10.0 (2019-01-05)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -785,7 +785,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
                 "[ \r\n\t]*"
                 ;; Possibly type or metadata
                 "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
-                "\\(\\sw+\\)?")
+                (concat "\\(" clojure--sym-regexp "\\)?"))
        (1 font-lock-keyword-face)
        (2 font-lock-function-name-face nil t))
       ;; (fn name? args ...)

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -709,7 +709,13 @@ POS."
     (should (eq (clojure-test-face-at 2 4) 'font-lock-type-face))
     (should (eq (clojure-test-face-at 5 5) nil))
     (should (eq (clojure-test-face-at 6 11) 'font-lock-keyword-face))
-    (should (eq (clojure-test-face-at 13 15) 'font-lock-function-name-face))))
+    (should (eq (clojure-test-face-at 13 15) 'font-lock-function-name-face)))
+  (clojure-test-with-temp-buffer "(s/def ::keyword)"
+    (should (eq (clojure-test-face-at 2 2) 'font-lock-type-face))
+    (should (eq (clojure-test-face-at 3 3) nil))
+    (should (eq (clojure-test-face-at 4 6) 'font-lock-keyword-face))
+    (should (eq (clojure-test-face-at 8 16) 'clojure-keyword-face))))
+
 
 (ert-deftest clojure-mode-syntax-table/variable-def ()
   :tags '(fontification syntax-table)


### PR DESCRIPTION
Fixes what is said here: https://github.com/clojure-emacs/clojure-mode/issues/445#issuecomment-340460753. The regex could be improved so feedback appreciated. Basically, it has to exclude words starting with `:` so it does not apply `function-name-face` to them (they are keywords)

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
