### PR TITLE
Fix font locking for non-alphanumeric chars in dynamic var names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Dynamic vars whose names contain non-alphanumeric characters are now font-locked correctly.
+
 ## 5.10.0 (2019-01-05)
 
 ### New features

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -847,7 +847,8 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
          "\\>")
        0 font-lock-builtin-face)
       ;; Dynamic variables - *something* or @*something*
-      ("\\(?:\\<\\|/\\)@?\\(\\*[a-z-]*\\*\\)\\>" 1 font-lock-variable-name-face)
+      (,(concat "\\(?:\\<\\|/\\)@?\\(\\*" clojure--sym-regexp "\\*\\)\\>")
+       1 font-lock-variable-name-face)
       ;; Global constants - nil, true, false
       (,(concat
          "\\<"

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -822,6 +822,8 @@ POS."
   (should (eq (clojure-test-face-at 2 11 "@*some-var*")
               'font-lock-variable-name-face))
   (should (eq (clojure-test-face-at 9 13 "some.ns/*var*")
+              'font-lock-variable-name-face))
+  (should (eq (clojure-test-face-at 1 11 "*some-var?*")
               'font-lock-variable-name-face)))
 
 (provide 'clojure-mode-font-lock-test)


### PR DESCRIPTION
e.g. `*foo?*`

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
