### PR TITLE
[Fix #506] Makes display version command return the actual version (2)

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -82,9 +82,8 @@
   :link '(emacs-commentary-link :tag "Commentary" "clojure-mode"))
 
 (defconst clojure-mode-version
-  (let ((thisbuffer (or load-file-name buffer-file-name)))
-    (with-temp-buffer (insert-file-contents thisbuffer)
-                      (lm-version)))
+  (eval-when-compile
+    (lm-version (or load-file-name buffer-file-name)))
   "The current version of `clojure-mode'.")
 
 (defface clojure-keyword-face


### PR DESCRIPTION
My previous PR (https://github.com/clojure-emacs/clojure-mode/pull/507), only partially solves the problem (https://github.com/clojure-emacs/clojure-mode/issues/506)

The byte-compiled file will look for the version in its headers but it has none.

The version has to be given to the byte compiled file at compile time (therefore using `eval-when-compile`).

**Difference in the .elc files:**
This PR:
![screenshot_20190228_022353](https://user-images.githubusercontent.com/5300711/53534651-159a8e00-3b00-11e9-94b7-1bc8596f3486.png)

master branch:
![screenshot_20190228_022436](https://user-images.githubusercontent.com/5300711/53534648-12070700-3b00-11e9-899a-a737311cc9b0.png)

---
And a small change: `(lm-version)` takes an argument, the file. This is cleaner than creating a temp buffer, inserting the contents of the current file and calling (lm-version) within this context.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
