### PR TITLE
[Fix #531] Don't match strings when using `clojure-rename-ns-alias`.

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2662,13 +2662,12 @@ lists up."
   (clojure--find-ns-in-direction 'backward)
   (let ((rgx (concat ":as +" current-alias))
         (bound (save-excursion (forward-list 1) (point))))
-    (when (save-excursion (search-forward-regexp rgx bound t))
-      (save-excursion
-        (while (re-search-forward rgx bound t)
-          (replace-match (concat ":as " new-alias))))
+    (when (search-forward-regexp rgx bound t)
+      (replace-match (concat ":as " new-alias))
       (save-excursion
         (while (re-search-forward (concat current-alias "/") nil t)
-          (replace-match (concat new-alias "/"))))
+          (when (not (nth 3 (syntax-ppss)))
+            (replace-match (concat new-alias "/")))))
       (save-excursion
         (while (re-search-forward (concat "#::" current-alias "{") nil t)
           (replace-match (concat "#::" new-alias "{"))))

--- a/test/clojure-mode-refactor-rename-ns-alias-test.el
+++ b/test/clojure-mode-refactor-rename-ns-alias-test.el
@@ -55,8 +55,44 @@
 
      (+ (lib/a 1) (b 2))"
 
-    (clojure--rename-ns-alias-internal "foo" "bar")))
+    (clojure--rename-ns-alias-internal "foo" "bar"))
 
-(provide 'clojure-mode-refactor-rename-ns-alias-test)
+  (when-refactoring-it "should skip strings"
+    "(ns cljr.core
+       (:require [my.lib :as lib]))
+
+     (def dirname \"/usr/local/lib/python3.6/site-packages\")
+
+     (+ (lib/a 1) (b 2))"
+
+    "(ns cljr.core
+       (:require [my.lib :as foo]))
+
+     (def dirname \"/usr/local/lib/python3.6/site-packages\")
+
+     (+ (foo/a 1) (b 2))"
+
+    (clojure--rename-ns-alias-internal "lib" "foo"))
+
+  (when-refactoring-it "should not skip comments"
+    "(ns cljr.core
+       (:require [my.lib :as lib]))
+
+     (def dirname \"/usr/local/lib/python3.6/site-packages\")
+
+     ;; TODO refactor using lib/foo
+     (+ (lib/a 1) (b 2))"
+
+    "(ns cljr.core
+       (:require [my.lib :as new-lib]))
+
+     (def dirname \"/usr/local/lib/python3.6/site-packages\")
+
+     ;; TODO refactor using new-lib/foo
+     (+ (new-lib/a 1) (b 2))"
+
+    (clojure--rename-ns-alias-internal "lib" "new-lib")))
+
+  (provide 'clojure-mode-refactor-rename-ns-alias-test)
 
 ;;; clojure-mode-refactor-rename-ns-alias-test.el ends here


### PR DESCRIPTION
Is it acceptable to use font locking to determine whether a string was matched?

- [X] The commits are consistent with our [contribution guidelines][1].
- [X] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [X] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).