### PR TITLE
Remove calls to provide and require for test-helper.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 	rm -f $(OBJS)
 
 test: $(PKGDIR)
-	$(CASK) exec buttercup -L . -L ./test/
+	$(CASK) exec buttercup
 
 test-checks:
 	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \

--- a/test/clojure-mode-convert-collection-test.el
+++ b/test/clojure-mode-convert-collection-test.el
@@ -26,7 +26,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'buttercup)
 
 (describe "clojure-convert-collection-to-map"

--- a/test/clojure-mode-cycling-test.el
+++ b/test/clojure-mode-cycling-test.el
@@ -25,7 +25,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'buttercup)
 
 (describe "clojure-cycle-privacy"

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -25,7 +25,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'cl-lib)
 (require 'buttercup)
 

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -24,7 +24,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'cl-lib)
 (require 'buttercup)
 (require 's)

--- a/test/clojure-mode-refactor-let-test.el
+++ b/test/clojure-mode-refactor-let-test.el
@@ -25,7 +25,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'buttercup)
 
 (describe "clojure--introduce-let-internal"

--- a/test/clojure-mode-refactor-rename-ns-alias-test.el
+++ b/test/clojure-mode-refactor-rename-ns-alias-test.el
@@ -18,7 +18,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'ert)
 
 (describe "clojure--rename-ns-alias-internal"

--- a/test/clojure-mode-refactor-threading-test.el
+++ b/test/clojure-mode-refactor-threading-test.el
@@ -26,7 +26,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'buttercup)
 
 (describe "clojure-thread"

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -20,7 +20,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'buttercup)
 
 (defmacro with-clojure-buffer-point (text &rest body)

--- a/test/clojure-mode-syntax-test.el
+++ b/test/clojure-mode-syntax-test.el
@@ -24,7 +24,6 @@
 ;;; Code:
 
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'buttercup)
 
 (defun non-func (form-a form-b)

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -23,7 +23,6 @@
 
 ;;; Code:
 (require 'clojure-mode)
-(require 'test-helper)
 (require 'cl-lib)
 (require 'buttercup)
 

--- a/test/utils/test-helper.el
+++ b/test/utils/test-helper.el
@@ -54,6 +54,4 @@ DESCRIPTION is the description of the spec."
        ,@body
        (expect (buffer-string) :to-equal ,after))))
 
-(provide 'test-helper)
-
 ;;; test-helper.el ends here


### PR DESCRIPTION
The require/provide machinery is intended for things that are to be loaded for
the benefit of end-users.

Placing test-helper under utils is enough to get buttercup to load it before the tests.

Addresses https://github.com/clojure-emacs/clojure-mode/issues/422#issuecomment-510120019

- [X] The commits are consistent with our [contribution guidelines][1].
- [X] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [X] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [X] You've updated the changelog (if adding/changing user-visible functionality).
- [X] You've updated the readme (if adding/changing user-visible functionality).