### PR TITLE
Add default keybindings for rename-ns-alias and add-arity refactorings, and refactor clojure-unwind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### New features
 
 * [#496](https://github.com/clojure-emacs/clojure-mode/issues/496): Highlight `[[wikilinks]]` in comments.
-* [#366](https://github.com/clojure-emacs/clj-refactor.el/issues/366): Add support for renaming ns aliases (`clojure-rename-ns-alias`).
-* [#410](https://github.com/clojure-emacs/clojure-mode/issues/410): Add support for adding an arity to a function (`clojure-add-arity`).
+* [#366](https://github.com/clojure-emacs/clj-refactor.el/issues/366): Add support for renaming ns aliases (`clojure-rename-ns-alias`, default binding `C-c C-r n r`).
+* [#410](https://github.com/clojure-emacs/clojure-mode/issues/410): Add support for adding an arity to a function (`clojure-add-arity`, default binding `C-c C-r a`), .
 
 ### Bugs fixed
 
@@ -21,6 +21,7 @@
 ### Changes
 
 * [#524](https://github.com/clojure-emacs/clojure-mode/issues/524): Add proper indentation rule for `delay` (same as for `future`).
+* [#538](https://github.com/clojure-emacs/clojure-mode/pull/538): Refactor `clojure-unwind` to take numeric prefix argument for unwinding N steps, and universal argument for unwinding completely. The dedicated `C-c C-r a` binding for `clojure-unwind-all`is now removed and replaced with the universal arg convention `C-u C-c C-r u`.
 
 ## 5.10.0 (2019-01-05)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2682,7 +2682,7 @@ lists up."
 ;;;###autoload
 (defun clojure-let-backward-slurp-sexp (&optional n)
   "Slurp the s-expression before the let form into the let form.
-With a numberic prefix argument slurp the previous N s-expression
+With a numeric prefix argument slurp the previous N s-expressions
 into the let form."
   (interactive "p")
   (let ((n (or n 1)))
@@ -2702,7 +2702,8 @@ into the let form."
 ;;;###autoload
 (defun clojure-let-forward-slurp-sexp (&optional n)
   "Slurp the next s-expression after the let form into the let form.
-With a numeric prefix argument slurp the next N s-expressions into the let form."
+With a numeric prefix argument slurp the next N s-expressions
+into the let form."
   (interactive "p")
   (unless n (setq n 1))
   (dotimes (_ n)
@@ -2731,8 +2732,8 @@ With a numeric prefix argument the let is introduced N lists up."
       (let ((rgx (concat ":as +" current-alias))
             (bound (save-excursion (forward-list 1) (point))))
         (if (save-excursion (search-forward-regexp rgx bound t))
-          (let ((new-alias (read-from-minibuffer "New alias: ")))
-            (clojure--rename-ns-alias-internal current-alias new-alias))
+            (let ((new-alias (read-from-minibuffer "New alias: ")))
+              (clojure--rename-ns-alias-internal current-alias new-alias))
           (message "Cannot find namespace alias: '%s'" current-alias))))))
 
 ;;;###autoload
@@ -2755,7 +2756,7 @@ With a numeric prefix argument the let is introduced N lists up."
      ((looking-back "\\[" 1)  ;; single-arity defn
       (let* ((bol (save-excursion (beginning-of-line) (point)))
              (same-line (save-excursion (re-search-backward "defn" bol t)))
-               (new-arity-text (concat (when same-line "\n") "([])\n[")))
+             (new-arity-text (concat (when same-line "\n") "([])\n[")))
         (re-search-backward " +\\[")
         (replace-match new-arity-text)
         (save-excursion

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -217,8 +217,6 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
     (define-key map (kbd "f") #'clojure-thread-first-all)
     (define-key map (kbd "C-l") #'clojure-thread-last-all)
     (define-key map (kbd "l") #'clojure-thread-last-all)
-    (define-key map (kbd "C-a") #'clojure-unwind-all)
-    (define-key map (kbd "a") #'clojure-unwind-all)
     (define-key map (kbd "C-p") #'clojure-cycle-privacy)
     (define-key map (kbd "p") #'clojure-cycle-privacy)
     (define-key map (kbd "C-(") #'clojure-convert-collection-to-list)
@@ -241,10 +239,13 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
     (define-key map (kbd "n h") #'clojure-insert-ns-form-at-point)
     (define-key map (kbd "n u") #'clojure-update-ns)
     (define-key map (kbd "n s") #'clojure-sort-ns)
+    (define-key map (kbd "n r") #'clojure-rename-ns-alias)
     (define-key map (kbd "s i") #'clojure-introduce-let)
     (define-key map (kbd "s m") #'clojure-move-to-let)
     (define-key map (kbd "s f") #'clojure-let-forward-slurp-sexp)
     (define-key map (kbd "s b") #'clojure-let-backward-slurp-sexp)
+    (define-key map (kbd "C-a") #'clojure-add-arity)
+    (define-key map (kbd "a") #'clojure-add-arity)
     map)
   "Keymap for Clojure refactoring commands.")
 (fset 'clojure-refactor-map clojure-refactor-map)
@@ -263,11 +264,13 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
         ["Cycle if, if-not" clojure-cycle-if]
         ["Cycle when, when-not" clojure-cycle-when]
         ["Cycle not" clojure-cycle-not]
+        ["Add function arity" clojure-add-arity]
         ("ns forms"
          ["Insert ns form at the top" clojure-insert-ns-form]
          ["Insert ns form here" clojure-insert-ns-form-at-point]
          ["Update ns form" clojure-update-ns]
-         ["Sort ns form" clojure-sort-ns])
+         ["Sort ns form" clojure-sort-ns]
+         ["Rename ns alias" clojure-rename-ns-alias])
         ("Convert collection"
          ["Convert to list" clojure-convert-collection-to-list]
          ["Convert to quoted list" clojure-convert-collection-to-quoted-list]

--- a/test/clojure-mode-refactor-threading-test.el
+++ b/test/clojure-mode-refactor-threading-test.el
@@ -227,6 +227,26 @@
     (clojure-unwind)
     (clojure-unwind))
 
+  (when-refactoring-it "should unwind N steps with numeric prefix arg"
+    "(->> [1 2 3 4 5]
+     (filter even?)
+     (map square)
+     sum)"
+
+    "(->> (sum (map square (filter even? [1 2 3 4 5]))))"
+
+    (clojure-unwind 3))
+
+  (when-refactoring-it "should unwind completely with universal prefix arg"
+    "(->> [1 2 3 4 5]
+     (filter even?)
+     (map square)
+     sum)"
+
+    "(sum (map square (filter even? [1 2 3 4 5])))"
+
+    (clojure-unwind '(4)))
+
   (when-refactoring-it "should unwind with function name"
     "(->> [1 2 3 4 5]
      sum


### PR DESCRIPTION
I placed these suggested bindings under the clojure-refactor-map and added them to the menubar:
`C-c C-r n r` -> `clojure-rename-ns-alias`
`C-c C-r a` -> `clojure-add-arity`

The `a` keybinding was taken by `clojure-unwind-all` which didn't made much sense, so I took the liberty of changing it to `U` as a "stronger" version of the existing `u -> clojure-unwind` binding.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
