### PR TITLE
Enhance the add arity refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Bugs fixed
 
 * [#520](https://github.com/clojure-emacs/clojure-mode/issues/508): Fix allow `clojure-align-cond-forms` to recognize qualified forms.
+* Enhance add arity refactoring to support a defn inside a reader conditional.
+
+### Changes
+
+* Enhance add arity refactoring to support new forms: letfn, fn, defmacro, defmethod, defprotocol, reify and proxy.
 
 ## 5.11.0 (2019-07-16)
 

--- a/test/clojure-mode-refactor-add-arity-test.el
+++ b/test/clojure-mode-refactor-add-arity-test.el
@@ -149,6 +149,202 @@ DESCRIPTION is a string with the description of the spec."
   ([arg]
    body))"
 
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a single-arity fn"
+    "(fn foo [arg]
+  body|)"
+
+    "(fn foo
+  ([|])
+  ([arg]
+   body))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a multi-arity fn"
+    "(fn foo
+  ([x y]
+   body)
+  ([a|rg]
+   body))"
+
+    "(fn foo
+  ([|])
+  ([x y]
+   body)
+  ([arg]
+   body))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a single-arity defmacro"
+    "(defmacro foo [arg]
+  body|)"
+
+    "(defmacro foo
+  ([|])
+  ([arg]
+   body))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a multi-arity defmacro"
+    "(defmacro foo
+  ([x y]
+   body)
+  ([a|rg]
+   body))"
+
+    "(defmacro foo
+  ([|])
+  ([x y]
+   body)
+  ([arg]
+   body))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a single-arity defmethod"
+    "(defmethod foo :bar [arg]
+  body|)"
+
+    "(defmethod foo :bar
+  ([|])
+  ([arg]
+   body))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a multi-arity defmethod"
+    "(defmethod foo :bar
+  ([x y]
+   body)
+  ([a|rg]
+   body))"
+
+    "(defmethod foo :bar
+  ([|])
+  ([x y]
+   body)
+  ([arg]
+   body))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a defn inside a reader conditional"
+    "#?(:clj
+   (defn foo
+     \"some docstring\"
+     ^{:bla \"meta\"}
+     |([arg]
+      body)))"
+
+    "#?(:clj
+   (defn foo
+     \"some docstring\"
+     ^{:bla \"meta\"}
+     ([|])
+     ([arg]
+      body)))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a defn inside a reader conditional with 2 platform tags"
+    "#?(:clj
+   (defn foo
+     \"some docstring\"
+     ^{:bla \"meta\"}
+     |([arg]
+      body))
+   :cljs
+   (defn foo
+     \"some docstring\"
+     ^{:bla \"meta\"}
+     ([arg]
+      body)))"
+
+    "#?(:clj
+   (defn foo
+     \"some docstring\"
+     ^{:bla \"meta\"}
+     ([|])
+     ([arg]
+      body))
+   :cljs
+   (defn foo
+     \"some docstring\"
+     ^{:bla \"meta\"}
+     ([arg]
+      body)))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a single-arity fn inside a letfn"
+    "(letfn [(foo [x]
+           bo|dy)]
+  (foo 3))"
+
+    "(letfn [(foo
+          ([|])
+          ([x]
+           body))]
+  (foo 3))"
+
+    (clojure-add-arity))
+
+    (when-refactoring-with-point-it "should handle a multi-arity fn inside a letfn"
+    "(letfn [(foo
+          ([x]
+           body)
+          |([x y]
+           body))]
+  (foo 3))"
+
+    "(letfn [(foo
+          ([|])
+          ([x]
+           body)
+          ([x y]
+           body))]
+  (foo 3))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a proxy"
+    "(proxy [Foo] []
+  (bar [arg]
+     body|))"
+
+    "(proxy [Foo] []
+  (bar
+    ([|])
+    ([arg]
+     body)))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a defprotocol"
+    "(defprotocol Foo
+  \"some docstring\"
+  (bar [arg] [x |y] \"some docstring\"))"
+
+    "(defprotocol Foo
+  \"some docstring\"
+  (bar [|] [arg] [x y] \"some docstring\"))"
+
+    (clojure-add-arity))
+
+  (when-refactoring-with-point-it "should handle a reify"
+    "(reify Foo
+  (bar [arg] body)
+  (blahs [arg]| body))"
+
+    "(reify Foo
+  (bar [arg] body)
+  (blahs [|])
+  (blahs [arg] body))"
+
     (clojure-add-arity)))
 
 (provide 'clojure-mode-refactor-add-arity-test)


### PR DESCRIPTION
Just came across a case which the current `clojure-add-arity` refactoring does not handle well i.e. when a `defn` lies within a reader conditional. This pull request modifies `clojure-add-arity` to support this case.

- [X] The commits are consistent with our [contribution guidelines][1].
- [X] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [X] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).