### PR TITLE
Support multiple consecutive reader comments (#_#_a b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#520](https://github.com/clojure-emacs/clojure-mode/issues/508): Fix allow `clojure-align-cond-forms` to recognize qualified forms.
 * Enhance add arity refactoring to support a defn inside a reader conditional.
+* [#404](https://github.com/clojure-emacs/clojure-mode/issues/404)/[#528]((https://github.com/clojure-emacs/clojure-mode/issues/528)) Fix syntax highlighting for multiple consecutive comment reader macros (`#_#_`)
 
 ### Changes
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -654,14 +654,16 @@ If JUSTIFY is non-nil, justify as well as fill the paragraph."
 ;; Code heavily borrowed from Slime.
 ;; https://github.com/slime/slime/blob/master/contrib/slime-fontifying-fu.el#L186
 (defvar clojure--comment-macro-regexp
-  (rx "#_" (* " ") (group-n 1 (not (any " "))))
+  (rx (seq (+ (seq "#_" (* " ")))) (group-n 1 (not (any " "))))
   "Regexp matching the start of a comment sexp.
 The beginning of match-group 1 should be before the sexp to be
 marked as a comment.  The end of sexp is found with
 `clojure-forward-logical-sexp'.")
 
 (defvar clojure--reader-and-comment-regexp
-  "#_ *\\(?1:[^ ]\\)\\|\\(?1:(comment\\_>\\)"
+  (rx (or (seq (+ (seq "#_" (* " ")))
+               (group-n 1 (not (any " "))))
+          (seq (group-n 1 "(comment" symbol-end))))
   "Regexp matching both `#_' macro and a comment sexp." )
 
 (defcustom clojure-comment-regexp clojure--comment-macro-regexp
@@ -687,7 +689,11 @@ what is considered a comment (affecting font locking).
               (nth 4 state))
           (clojure--search-comment-macro-internal limit)
         (goto-char start)
-        (clojure-forward-logical-sexp 1)
+        ;; Count how many #_ we got and step by that many sexps
+        ;; For (comment ...), step at least 1 sexp
+        (clojure-forward-logical-sexp
+         (max (count-matches (rx "#_") (elt md 0) (elt md 1))
+              1))
         ;; Data for (match-end 1).
         (setf (elt md 3) (point))
         (set-match-data md)

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -133,11 +133,35 @@ DESCRIPTION is the description of the spec."
     ("#_"
      (1 2 nil))
 
+    ("#_#_"
+     (1 2 nil))
+
+    ("#_#_"
+     (3 2 font-lock-comment-face))
+
+    ("#_ #_"
+     (1 3 nil))
+
+    ("#_ #_"
+     (4 2 font-lock-comment-face))
+
     ("#_ \n;; some crap\n (lala 0101\n lao\n\n 0 0i)"
      (1 2 nil))
 
     ("#_ \n;; some crap\n (lala 0101\n lao\n\n 0 0i)"
-     (5 41 font-lock-comment-face)))
+     (5 41 font-lock-comment-face))
+
+    ("#_#_ \n;; some crap\n (lala 0101\n lao\n\n 0 0i)\n;; more crap\n (foobar tnseriao)"
+     (1 4 nil))
+
+    ("#_ #_ \n;; some crap\n (lala 0101\n lao\n\n 0 0i)\n;; more crap\n (foobar tnseriao)"
+     (1 5 nil))
+
+    ("#_#_ \n;; some crap\n (lala 0101\n lao\n\n 0 0i)\n;; more crap\n (foobar tnseriao)"
+     (7 75 font-lock-comment-face))
+
+    ("#_ #_ \n;; some crap\n (lala 0101\n lao\n\n 0 0i)\n;; more crap\n (foobar tnseriao)"
+     (8 75 font-lock-comment-face)))
 
   (when-fontifying-it "should handle namespace declarations"
     ("(ns .validns)"


### PR DESCRIPTION
Modified the default regexps and the heuristic to find the end of the region to
comment out.

Previously Emacs would treat the second `#_` as the commented form, and then
highlight the following two forms as usual. Now it (mostly) matches what Clojure
actually evaluates. Things get weird when you start mixing `#_` and forms, but
this fixes the most common use cases, like key-value-pairs.

Tagging #404/#528 for visibility

**Note:** I couldn't get the tests to work locally, so I'd be grateful if someone wants to add a test case for the above.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
