### PR TITLE
Font lock additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add custom faces for definitions. This feature makes it possible to use a different face when introducing names. The customizable faces are `clojure-function-definition-face`, `clojure-variable-definition-face`, `clojure-type-definition-face`, `clojure-keyword-definition-face` and `clojure-namespace-definition-face`. The new faces have the same default face as before that they inherit.
+
 ### Bugs fixed
 
 * [#520](https://github.com/clojure-emacs/clojure-mode/issues/508): Fix allow `clojure-align-cond-forms` to recognize qualified forms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Add custom faces for definitions. This feature makes it possible to use a different face when introducing names. The customizable faces are `clojure-function-definition-face`, `clojure-variable-definition-face`, `clojure-type-definition-face`, `clojure-keyword-definition-face` and `clojure-namespace-definition-face`. The new faces have the same default face as before that they inherit.
+- Add support for Schema `defschema` as a type face.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#520](https://github.com/clojure-emacs/clojure-mode/issues/508): Fix allow `clojure-align-cond-forms` to recognize qualified forms.
 * Enhance add arity refactoring to support a defn inside a reader conditional.
+* Add `definterface` to the list of font locks with type face like `defrecord` et al.
 
 ### Changes
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -807,7 +807,10 @@ any number of matches of `clojure--sym-forbidden-rest-chars'.")
                 "\\(\\sw+\\)?")
        (1 font-lock-keyword-face)
        (2 'clojure-type-definition-face nil t))
-      ;; Known other type definition e.g. Schema (s/defschema FooBar ...)
+      ;; Known other type definition
+      ;; - Schema (s/defschema FooBar ...) -> clojure-type-definition-face
+      ;; - spec (s/def :foobar ...) -> clojure-keyword-definition-face
+      ;; May have keyword as the name like
       (,(concat "(\\(?:" clojure--sym-regexp "/\\)?\\("
                 (regexp-opt '("defschema"))
                 ;; Function declarations
@@ -819,11 +822,10 @@ any number of matches of `clojure--sym-forbidden-rest-chars'.")
                 (concat "\\(" clojure--sym-regexp "\\)?"))
        (1 font-lock-keyword-face)
        (2 'clojure-type-definition-face nil t))
-      ;; Definition with a keyword in the name e.g. spec (s/def :foobar ...)
-      (,(concat "(\\(?:" clojure--sym-regexp "/\\)?"
-                "\\(def[^ \r\n\t]*\\)"
+      (,(concat "(\\(?:" clojure--sym-regexp "/\\)?\\("
+                (regexp-opt '("def"))
                 ;; Function declarations
-                "\\>"
+                "\\)\\>"
                 ;; Any whitespace
                 "[ \r\n\t]*"
                 ;; Possibly type or metadata

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -807,6 +807,18 @@ any number of matches of `clojure--sym-forbidden-rest-chars'.")
                 "\\(\\sw+\\)?")
        (1 font-lock-keyword-face)
        (2 'clojure-type-definition-face nil t))
+      ;; Known other type definition e.g. Schema (s/defschema FooBar ...)
+      (,(concat "(\\(?:" clojure--sym-regexp "/\\)?\\("
+                (regexp-opt '("defschema"))
+                ;; Function declarations
+                "\\)\\>"
+                ;; Any whitespace
+                "[ \r\n\t]*"
+                ;; Possibly type or metadata
+                "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
+                (concat "\\(" clojure--sym-regexp "\\)?"))
+       (1 font-lock-keyword-face)
+       (2 'clojure-type-definition-face nil t))
       ;; Definition with a keyword in the name e.g. spec (s/def :foobar ...)
       (,(concat "(\\(?:" clojure--sym-regexp "/\\)?"
                 "\\(def[^ \r\n\t]*\\)"

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -823,7 +823,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'.")
        (1 font-lock-keyword-face)
        (2 'clojure-type-definition-face nil t))
       (,(concat "(\\(?:" clojure--sym-regexp "/\\)?\\("
-                (regexp-opt '("def"))
+                (regexp-opt '("def" "reg-event-db" "reg-event-fx" "reg-sub" "reg-fx" "reg-cofx"))
                 ;; Function declarations
                 "\\)\\>"
                 ;; Any whitespace

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -794,10 +794,10 @@ any number of matches of `clojure--sym-forbidden-rest-chars'.")
                 "\\(\\sw+\\)?")
        (1 font-lock-keyword-face)
        (2 'clojure-variable-definition-face nil t))
-      ;; Type definition
+      ;; Core type definition
       (,(concat "(\\(?:clojure.core/\\)?\\("
                 (regexp-opt '("defstruct" "deftype" "defprotocol"
-                              "defrecord"))
+                              "defrecord" "definterface"))
                 ;; type declarations
                 "\\)\\>"
                 ;; Any whitespace

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -141,61 +141,61 @@ DESCRIPTION is the description of the spec."
 
   (when-fontifying-it "should handle namespace declarations"
     ("(ns .validns)"
-     (5 12 font-lock-type-face))
+     (5 12 clojure-namespace-definition-face))
 
     ("(ns =validns)"
-     (5 12 font-lock-type-face))
+     (5 12 clojure-namespace-definition-face))
 
     ("(ns .ValidNs=<>?+|?*.)"
-     (5 21 font-lock-type-face))
+     (5 21 clojure-namespace-definition-face))
 
     ("(ns ValidNs<>?+|?*.b*ar.ba*z)"
-     (5 28 font-lock-type-face))
+     (5 28 clojure-namespace-definition-face))
 
     ("(ns other.valid.ns)"
-     (5 18 font-lock-type-face))
+     (5 18 clojure-namespace-definition-face))
 
     ("(ns oneword)"
-     (5 11 font-lock-type-face))
+     (5 11 clojure-namespace-definition-face))
 
     ("(ns foo.bar)"
-     (5 11 font-lock-type-face))
+     (5 11 clojure-namespace-definition-face))
 
     ("(ns Foo.bar)"
-     (5 11 font-lock-type-face)
-     (5 11 font-lock-type-face)
-     (5 11 font-lock-type-face))
+     (5 11 clojure-namespace-definition-face)
+     (5 11 clojure-namespace-definition-face)
+     (5 11 clojure-namespace-definition-face))
 
     ("(ns Foo-bar)"
-     (5 11 font-lock-type-face)
-     (5 11 font-lock-type-face))
+     (5 11 clojure-namespace-definition-face)
+     (5 11 clojure-namespace-definition-face))
 
     ("(ns foo-Bar)"
-     (5 11 font-lock-type-face))
+     (5 11 clojure-namespace-definition-face))
 
     ("(ns one.X)"
-     (5 9 font-lock-type-face))
+     (5 9 clojure-namespace-definition-face))
 
     ("(ns ^:md ns-name)"
-     (10 16 font-lock-type-face))
+     (10 16 clojure-namespace-definition-face))
 
     ("(ns ^:md \n  ns-name)"
-     (13 19 font-lock-type-face))
+     (13 19 clojure-namespace-definition-face))
 
     ("(ns ^:md1 ^:md2 ns-name)"
-     (17 23 font-lock-type-face))
+     (17 23 clojure-namespace-definition-face))
 
     ("(ns ^:md1 ^{:md2 true} ns-name)"
-     (24 30 font-lock-type-face))
+     (24 30 clojure-namespace-definition-face))
 
     ("(ns ^{:md2 true} ^:md1 ns-name)"
-     (24 30 font-lock-type-face))
+     (24 30 clojure-namespace-definition-face))
 
     ("(ns ^:md1 ^{:md2 true} \n  ns-name)"
-     (27 33 font-lock-type-face))
+     (27 33 clojure-namespace-definition-face))
 
     ("(ns ^{:md2 true} ^:md1 \n  ns-name)"
-     (27 33 font-lock-type-face)))
+     (27 33 clojure-namespace-definition-face)))
 
   (when-fontifying-it "should handle one word"
     (" oneword"
@@ -723,24 +723,24 @@ DESCRIPTION is the description of the spec."
      (2 4 font-lock-type-face)
      (5 5 nil)
      (6 18 font-lock-keyword-face)
-     (23 25 font-lock-function-name-face))
+     (23 25 clojure-function-definition-face))
 
     ("(clo/defbar foo nil)"
      (2 4 font-lock-type-face)
      (5 5 nil)
      (6 11 font-lock-keyword-face)
-     (13 15 font-lock-function-name-face))
+     (13 15 clojure-function-definition-face))
 
     ("(s/def ::keyword)"
      (2 2 font-lock-type-face)
      (3 3 nil)
      (4 6 font-lock-keyword-face)
-     (8 16 clojure-keyword-face)))
+     (8 16 clojure-keyword-definition-face)))
 
   (when-fontifying-it "should handle variables defined with def"
     ("(def foo 10)"
      (2 4 font-lock-keyword-face)
-     (6 8 font-lock-variable-name-face)))
+     (6 8 clojure-variable-definition-face)))
 
   (when-fontifying-it "should handle variables definitions of type string"
     ("(def foo \"hello\")"
@@ -776,35 +776,35 @@ DESCRIPTION is the description of the spec."
   (when-fontifying-it "should handle deftype"
     ("(deftype Foo)"
      (2 8 font-lock-keyword-face)
-     (10 12 font-lock-type-face)))
+     (10 12 clojure-type-definition-face)))
 
   (when-fontifying-it "should handle defn"
     ("(defn foo [x] x)"
      (2 5 font-lock-keyword-face)
-     (7 9 font-lock-function-name-face)))
+     (7 9 clojure-function-definition-face)))
 
   (when-fontifying-it "should handle a custom def with special chars 1"
     ("(defn* foo [x] x)"
      (2 6 font-lock-keyword-face)
-     (8 10 font-lock-function-name-face)))
+     (8 10 clojure-function-definition-face)))
 
   (when-fontifying-it "should handle a custom def with special chars 2"
     ("(defsomething! foo [x] x)"
      (2 14 font-lock-keyword-face)
-     (16 18 font-lock-function-name-face)))
+     (16 18 clojure-function-definition-face)))
 
   (when-fontifying-it "should handle a custom def with special chars 3"
     ("(def-something foo [x] x)"
      (2 14 font-lock-keyword-face))
 
     ("(def-something foo [x] x)"
-     (16 18 font-lock-function-name-face)))
+     (16 18 clojure-function-definition-face)))
 
   (when-fontifying-it "should handle fn"
     ;; try to byte-recompile the clojure-mode.el when the face of 'fn' is 't'
     ("(fn foo [x] x)"
      (2 3 font-lock-keyword-face)
-     ( 5 7 font-lock-function-name-face)))
+     ( 5 7 clojure-function-definition-face)))
 
   (when-fontifying-it "should handle lambda-params"
     ("#(+ % %2 %3 %&)"

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -778,6 +778,11 @@ DESCRIPTION is the description of the spec."
      (2 8 font-lock-keyword-face)
      (10 12 clojure-type-definition-face)))
 
+  (when-fontifying-it "should handle definterface"
+    ("(definterface FooBar)"
+     (2 13 font-lock-keyword-face)
+     (15 20 clojure-type-definition-face)))
+
   (when-fontifying-it "should handle defn"
     ("(defn foo [x] x)"
      (2 5 font-lock-keyword-face)

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -805,6 +805,13 @@ DESCRIPTION is the description of the spec."
     ("(def-something foo [x] x)"
      (16 18 clojure-function-definition-face)))
 
+  (when-fontifying-it "should handle a known non-core def with type behavior"
+    ("(s/defschema FooBar)"
+     (2 2 font-lock-type-face)
+     (3 3 nil)
+     (4 12 font-lock-keyword-face)
+     (14 19 clojure-type-definition-face)))
+
   (when-fontifying-it "should handle fn"
     ;; try to byte-recompile the clojure-mode.el when the face of 'fn' is 't'
     ("(fn foo [x] x)"


### PR DESCRIPTION
I would like to propose the following changes to font locking. They make it really easy to emphasize important (top level) definitions by e.g. font-size or other. I have been using this for a couple years already and polished it up a bit to be hopefully accepted. Thank you for your consideration.

![possibilities](https://user-images.githubusercontent.com/823661/67858284-8677c700-fb21-11e9-948f-8e3751257837.png)

- Add specific customizable faces of different definition types.
- Support `definterface` like `defprotocol` (seems to be missing).
- Support Schema `defschema` as a type definition.

The customizable faces are
- `clojure-function-definition-face`,
- `clojure-variable-definition-face`,
- `clojure-type-definition-face`,
- `clojure-keyword-definition-face` and
- `clojure-namespace-definition-face`.

The new faces have the same default face as before that they inherit.

I wonder if this should also be included in the README but it is readily available in the wonderful Emacs customize feature.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
