### PR TITLE
[Fix #551] Indent `clojure-align` region before aligning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#551](https://github.com/clojure-emacs/clojure-mode/issues/551): Indent `clojure-align` region before aligning.
 * [#520](https://github.com/clojure-emacs/clojure-mode/issues/508): Fix allow `clojure-align-cond-forms` to recognize qualified forms.
 * Enhance add arity refactoring to support a defn inside a reader conditional.
 * [#404](https://github.com/clojure-emacs/clojure-mode/issues/404)/[#528]((https://github.com/clojure-emacs/clojure-mode/issues/528)) Fix syntax highlighting for multiple consecutive comment reader macros (`#_#_`)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1268,15 +1268,16 @@ When called from lisp code align everything between BEG and END."
         (save-excursion
           (while (search-forward-regexp "^ *\n" sexp-end 'noerror)
             (cl-incf count)))
+        ;; Pre-indent the region to avoid aligning to improperly indented
+        ;; contents (#551). Also fixes #360.
+        (indent-region (point) sexp-end)
         (dotimes (_ count)
           (align-region (point) sexp-end nil
                         `((clojure-align (regexp . clojure--search-whitespace-after-next-sexp)
                                          (group . 1)
                                          (separate . ,clojure-align-separator)
                                          (repeat . t)))
-                        nil))
-        ;; Reindent after aligning because of #360.
-        (indent-region (point) sexp-end)))))
+                        nil))))))
 
 ;;; Indentation
 (defun clojure-indent-region (beg end)

--- a/test/clojure-mode-indentation-test.el
+++ b/test/clojure-mode-indentation-test.el
@@ -659,6 +659,13 @@ x
     "#?@(:clj  [2]
     :cljs [2])")
 
+  (it "should handle improperly indented content"
+    (let ((content "(let [a-long-name 10\nb 20])")
+          (aligned-content "(let [a-long-name 10\n      b           20])"))
+      (with-clojure-buffer content
+        (call-interactively #'clojure-align)
+        (expect (buffer-string) :to-equal aligned-content))))
+
   (it "should not align reader conditionals by default"
     (let ((content "#?(:clj 2\n   :cljs 2)"))
       (with-clojure-buffer content


### PR DESCRIPTION
This prevents issues when aligning improperly indented code. Before, the region
would be aligned while retaining the improper indentation. The follow-up
indentation step would then break the alignment that was just performed.

With this commit, we switch the order by indenting first then aligning. This
retains compatibility with the test cases in #360.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
