### PR TITLE
Fix ns detection for complex metadata

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1994,7 +1994,7 @@ Returns a list pair, e.g. (\"defn\" \"abc\") or (\"deftest\" \"some-test\")."
 \"Non-logical\" sexp are ^metadata and #reader.macros."
   (comment-normalize-vars)
   (comment-forward (point-max))
-  (looking-at-p "\\^\\|#:?:?[[:alpha:]]"))
+  (looking-at-p "\\(?:#?\\^\\)\\|#:?:?[[:alpha:]]"))
 
 (defun clojure-forward-logical-sexp (&optional n)
   "Move forward N logical sexps.


### PR DESCRIPTION
See https://github.com/clojure-emacs/cider/issues/2821

Use clojure-forward-logical-sexp to reliably skip metadata instead of error-prone regex.

The previous variable `clojure-namespace-name-regex` is kept as obsolete in case it breaks other packages - can remove it directly if that's preferred.

One of the commented out `TODO`  tests used a old metadata syntax `#^{:bar true}` which wasn't supported by `clojure--looking-at-non-logical-sexp` 

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
