### PR TITLE
Rename ns alias improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#556](https://github.com/clojure-emacs/clojure-mode/issues/556): `clojure-rename-ns-alias` picks up existing aliases for minibuffer completion.
+
 ### Bugs fixed
 
+* [#556](https://github.com/clojure-emacs/clojure-mode/issues/556): Fix renaming of ns aliases containing regex characters.
+* [#555](https://github.com/clojure-emacs/clojure-mode/issues/555): Fix ns detection for ns forms with complex metadata.
 * [#550](https://github.com/clojure-emacs/clojure-mode/issues/550): Fix `outline-regexp` so `outline-insert-heading` behaves correctly.
 * [#551](https://github.com/clojure-emacs/clojure-mode/issues/551): Indent `clojure-align` region before aligning.
 * [#520](https://github.com/clojure-emacs/clojure-mode/issues/508): Fix allow `clojure-align-cond-forms` to recognize qualified forms.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2686,16 +2686,16 @@ lists up."
 (defun clojure--rename-ns-alias-internal (current-alias new-alias)
   "Rename a namespace alias CURRENT-ALIAS to NEW-ALIAS."
   (clojure--find-ns-in-direction 'backward)
-  (let ((rgx (concat ":as +" current-alias))
+  (let ((rgx (concat ":as +" (regexp-quote current-alias)))
         (bound (save-excursion (forward-list 1) (point))))
     (when (search-forward-regexp rgx bound t)
       (replace-match (concat ":as " new-alias))
       (save-excursion
-        (while (re-search-forward (concat current-alias "/") nil t)
+        (while (re-search-forward (concat (regexp-quote current-alias) "/") nil t)
           (when (not (nth 3 (syntax-ppss)))
             (replace-match (concat new-alias "/")))))
       (save-excursion
-        (while (re-search-forward (concat "#::" current-alias "{") nil t)
+        (while (re-search-forward (concat "#::" (regexp-quote current-alias) "{") nil t)
           (replace-match (concat "#::" new-alias "{"))))
       (message "Successfully renamed alias '%s' to '%s'" current-alias new-alias))))
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2702,7 +2702,7 @@ lists up."
 (defun clojure--rename-ns-alias-internal (current-alias new-alias)
   "Rename a namespace alias CURRENT-ALIAS to NEW-ALIAS."
   (clojure--find-ns-in-direction 'backward)
-  (let ((rgx (concat ":as +" (regexp-quote current-alias)))
+  (let ((rgx (concat ":as +" (regexp-quote current-alias) "\\_>"))
         (bound (save-excursion (forward-list 1) (point))))
     (when (search-forward-regexp rgx bound t)
       (replace-match (concat ":as " new-alias))
@@ -2767,7 +2767,7 @@ With a numeric prefix argument the let is introduced N lists up."
     (let* ((current-alias (completing-read "Current alias: "
                                            (clojure-collect-ns-aliases
                                             (thing-at-point 'list))))
-           (rgx (concat ":as +" current-alias))
+           (rgx (concat ":as +" (regexp-quote current-alias) "\\_>"))
            (bound (save-excursion (forward-list 1) (point))))
       (if (save-excursion (search-forward-regexp rgx bound t))
           (let ((new-alias (read-from-minibuffer "New alias: ")))

--- a/test/clojure-mode-refactor-rename-ns-alias-test.el
+++ b/test/clojure-mode-refactor-rename-ns-alias-test.el
@@ -95,8 +95,34 @@
      ;; TODO refactor using new-lib/foo
      (+ (new-lib/a 1) (b 2))"
 
-    (clojure--rename-ns-alias-internal "lib" "new-lib")))
+    (clojure--rename-ns-alias-internal "lib" "new-lib"))
 
-  (provide 'clojure-mode-refactor-rename-ns-alias-test)
+  (when-refactoring-it "should escape regex characters"
+    "(ns test.ns
+  (:require [my.math.subtraction :as math.-]
+            [my.math.multiplication :as math.*]))
+
+(math.*/operator 1 (math.-/subtract 2 3))"
+    "(ns test.ns
+  (:require [my.math.subtraction :as math.-]
+            [my.math.multiplication :as m*]))
+
+(m*/operator 1 (math.-/subtract 2 3))"
+    (clojure--rename-ns-alias-internal "math.*" "m*"))
+
+  (it "should offer completions"
+    (expect
+     (clojure-collect-ns-aliases
+      "(ns test.ns
+  (:require [my.math.subtraction :as math.-]
+            [my.math.multiplication :as math.*]
+            [clojure.spec.alpha :as s]
+            ;; [clojure.spec.alpha2 :as s2]
+            [symbols :as abc123.-$#.%*+!@]))
+
+(math.*/operator 1 (math.-/subtract 2 3))")
+     :to-equal '("abc123.-$#.%*+!@" "s" "math.*" "math.-"))))
+
+(provide 'clojure-mode-refactor-rename-ns-alias-test)
 
 ;;; clojure-mode-refactor-rename-ns-alias-test.el ends here

--- a/test/clojure-mode-refactor-rename-ns-alias-test.el
+++ b/test/clojure-mode-refactor-rename-ns-alias-test.el
@@ -43,6 +43,23 @@
      (+ (foo/a 1) (b 2))"
 
     (clojure--rename-ns-alias-internal "lib" "foo"))
+  (when-refactoring-it "should handle multiple aliases with common prefixes"
+
+    "(ns foo
+  (:require [clojure.string :as string]
+            [clojure.spec.alpha :as s]
+            [clojure.java.shell :as shell]))
+
+(s/def ::abc string/blank?)
+"
+    "(ns foo
+  (:require [clojure.string :as string]
+            [clojure.spec.alpha :as spec]
+            [clojure.java.shell :as shell]))
+
+(spec/def ::abc string/blank?)
+"
+    (clojure--rename-ns-alias-internal "s" "spec"))
 
   (when-refactoring-it "should handle ns declarations with missing as"
     "(ns cljr.core


### PR DESCRIPTION
Some minor improvements to the command `clojure-rename-ns-alias`, offering minibuffer completion of existing aliases and using regexp-quote, so that namespaces containing characters like `*` or `+` can be renamed correctly without need for manual escaping.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
