### PR TITLE
Fix clojure--sym-regexp search for namespace symbols

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1922,7 +1922,8 @@ DIRECTION is `forward' or `backward'."
           (save-match-data
             (goto-char end)
             (clojure-forward-logical-sexp)
-            (when (and (looking-back clojure--sym-regexp end 'greedy)
+            (clojure-backward-logical-sexp)
+            (when (and (looking-at clojure--sym-regexp)
                        (not (clojure--in-string-p))
                        (not (clojure--in-comment-p)))
               (setq candidate (match-string-no-properties 0)))))))


### PR DESCRIPTION
This PR demonstrates a fix for `cider-repl-set-ns` command. 

Issue appeared with namespaces in the form of e.g. `aoc-2019.puzzles.day14`.
For a file within this namespace inner function `clojure--find-ns-in-direction` would return `.puzzles.day14`, which would render cider repl unusable.

Emacs version: GNU Emacs 26.3 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.10) of 2019-08-29
OS: linux
clojure-mode version: `M-x clojure-mode-display-version` reports `clojure-mode (version nil)`. 
It was installed as part of doom-emacs, HEAD is at 
`64ed043 * origin/master update find-ns tests`
