### PR TITLE
Inline and fix syntax table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changes
 
+* Inline definition of `clojure-mode-syntax-table` and support `'` quotes in symbols and commas as whitespace.
 * Enhance add arity refactoring to support a `defn` inside a reader conditional.
 * Enhance add arity refactoring to support new forms: `letfn`, `fn`, `defmacro`, `defmethod`, `defprotocol`, `reify` and `proxy`.
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1952,7 +1952,7 @@ DIRECTION is `forward' or `backward'."
             (goto-char end)
             (clojure-forward-logical-sexp)
             (unless (or (clojure--in-string-p) (clojure--in-comment-p))
-              (setq candidate (thing-at-point 'symbol)))))))
+              (setq candidate (string-remove-prefix "'" (thing-at-point 'symbol))))))))
     candidate))
 
 (defun clojure-find-ns ()

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -316,6 +316,7 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
     (modify-syntax-entry ?\xa0 " " table) ; non-breaking space
     (modify-syntax-entry ?\t " " table)
     (modify-syntax-entry ?\f " " table)
+    (modify-syntax-entry ?, " " table)
 
     ;; Delimiters
     (modify-syntax-entry ?\( "()" table)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -302,19 +302,45 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
   "Keymap for Clojure mode.")
 
 (defvar clojure-mode-syntax-table
-  (let ((table (copy-syntax-table emacs-lisp-mode-syntax-table)))
-    (modify-syntax-entry ?\{ "(}" table)
-    (modify-syntax-entry ?\} "){" table)
+  (let ((table (make-syntax-table)))
+    ;; Initialize ASCII charset as symbol syntax
+    (modify-syntax-entry '(0 . 127) "_" table)
+
+    ;; Word syntax
+    (modify-syntax-entry '(?0 . ?9) "w" table)
+    (modify-syntax-entry '(?a . ?z) "w" table)
+    (modify-syntax-entry '(?A . ?Z) "w" table)
+
+    ;; Whitespace
+    (modify-syntax-entry ?\s " " table)
+    (modify-syntax-entry ?\xa0 " " table) ; non-breaking space
+    (modify-syntax-entry ?\t " " table)
+    (modify-syntax-entry ?\f " " table)
+
+    ;; Delimiters
+    (modify-syntax-entry ?\( "()" table)
+    (modify-syntax-entry ?\) ")(" table)
     (modify-syntax-entry ?\[ "(]" table)
     (modify-syntax-entry ?\] ")[" table)
-    (modify-syntax-entry ?? "_ p" table) ; ? is a prefix outside symbols
-    (modify-syntax-entry ?# "_ p" table) ; # is allowed inside keywords (#399)
+    (modify-syntax-entry ?\{ "(}" table)
+    (modify-syntax-entry ?\} "){" table)
+
+    ;; Prefix chars
+    (modify-syntax-entry ?` "'" table)
     (modify-syntax-entry ?~ "'" table)
     (modify-syntax-entry ?^ "'" table)
     (modify-syntax-entry ?@ "'" table)
+    (modify-syntax-entry ?? "_ p" table) ; ? is a prefix outside symbols
+    (modify-syntax-entry ?# "_ p" table) ; # is allowed inside keywords (#399)
+
+    ;; Others
+    (modify-syntax-entry ?\; "<" table) ; comment start
+    (modify-syntax-entry ?\n ">" table) ; comment end
+    (modify-syntax-entry ?\" "\"" table) ; string
+    (modify-syntax-entry ?\\ "\\" table) ; escape
+
     table)
-  "Syntax table for Clojure mode.
-Inherits from `emacs-lisp-mode-syntax-table'.")
+  "Syntax table for Clojure mode.")
 
 (defconst clojure--prettify-symbols-alist
   '(("fn"  . ?λ)))

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -333,6 +333,7 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
     (modify-syntax-entry ?@ "'" table)
     (modify-syntax-entry ?? "_ p" table) ; ? is a prefix outside symbols
     (modify-syntax-entry ?# "_ p" table) ; # is allowed inside keywords (#399)
+    (modify-syntax-entry ?' "_ p" table) ; ' is allowed anywhere but the start of symbols
 
     ;; Others
     (modify-syntax-entry ?\; "<" table) ; comment start
@@ -772,10 +773,10 @@ Called by `imenu--generic-function'."
         (goto-char start)))))
 
 (eval-and-compile
-  (defconst clojure--sym-forbidden-rest-chars "][\";\'@\\^`~\(\)\{\}\\,\s\t\n\r"
+  (defconst clojure--sym-forbidden-rest-chars "][\";@\\^`~\(\)\{\}\\,\s\t\n\r"
     "A list of chars that a Clojure symbol cannot contain.
 See definition of 'macros': URL `http://git.io/vRGLD'.")
-  (defconst clojure--sym-forbidden-1st-chars (concat clojure--sym-forbidden-rest-chars "0-9:")
+  (defconst clojure--sym-forbidden-1st-chars (concat clojure--sym-forbidden-rest-chars "0-9:'")
     "A list of chars that a Clojure symbol cannot start with.
 See the for-loop: URL `http://git.io/vRGTj' lines: URL
 `http://git.io/vRGIh', URL `http://git.io/vRGLE' and value

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -417,6 +417,16 @@ DESCRIPTION is the description of the spec."
      (9 10 nil)
      (12 29 nil)))
 
+  (when-fontifying-it "should handle quotes in tail of symbols and keywords"
+    ("'quot'ed'/sy'm'bol''"
+     (2 9 font-lock-type-face)
+     (10 20 nil))
+
+    (":qu'ote'd''/key'word'"
+     (2 11 font-lock-type-face)
+     (12 12 default)
+     (13 21 clojure-keyword-face)))
+
   (when-fontifying-it "should handle very complex stuff"
     ("  ve/yCom|pLex.stu-ff"
      (3 4 font-lock-type-face)

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -77,6 +77,7 @@ TESTS are lists of the form (content (start end expected-face)*).  For each test
 check that each `expected-face` is found in `content` between `start` and `end`.
 
 DESCRIPTION is the description of the spec."
+  (declare (indent 1))
   `(it ,description
      (dolist (test (quote ,tests))
        (apply #'expect-faces-at test))))
@@ -797,8 +798,8 @@ DESCRIPTION is the description of the spec."
     ("(def foo \"usage\" \"hello\"   )"
      (18 24 font-lock-string-face))
 
-     ("(def foo \"usage\" \n  \"hello\")"
-      (21 27 font-lock-string-face))
+    ("(def foo \"usage\" \n  \"hello\")"
+     (21 27 font-lock-string-face))
 
     ("(def foo \n  \"usage\" \"hello\")"
      (13 19 font-lock-doc-face))
@@ -864,8 +865,8 @@ DESCRIPTION is the description of the spec."
 
   (when-fontifying-it "should handle keyword-meta"
     ("^:meta-data"
-      (1 1 nil)
-      (2 11 clojure-keyword-face)))
+     (1 1 nil)
+     (2 11 clojure-keyword-face)))
 
   (when-fontifying-it "should handle a keyword with allowed characters"
     (":aaa#bbb"

--- a/test/utils/test-helper.el
+++ b/test/utils/test-helper.el
@@ -34,6 +34,7 @@
 
 (defmacro with-clojure-buffer (text &rest body)
   "Create a temporary buffer, insert TEXT, switch to clojure-mode and evaluate BODY."
+  (declare (indent 1))
   `(with-temp-buffer
      (erase-buffer)
      (insert ,text)
@@ -49,6 +50,7 @@ AFTER.
 BODY should contain the refactoring that transforms BEFORE into AFTER.
 
 DESCRIPTION is the description of the spec."
+  (declare (indent 1))
   `(it ,description
      (with-clojure-buffer ,before
        ,@body


### PR DESCRIPTION
In Clojure single quotes `'` can be part of a symbol literal anywhere except the head, this is stated explicitly in https://clojure.org/reference/reader and recently confirmed by Alex Miller on the Clojurians Slack.

Changing the syntax of `'` in the syntax table affects the output of functions like `(thing-at-point 'symbol)` which currently does not treat quotes as part of the symbol. This in turn affects `cider-symbol-at-point` and dependent functions like`cider-doc`, which currently does not work on vars named eg. `foo'` or `hawai'i`

I also took the liberty of inlining the definition of clojure-mode's syntax table rather than inheriting and overriding bits from `emacs-lisp-mode` (which in turn inherits from `lisp-mode`), making it simpler to understand it as a whole.

Also added commas as whitespace to the syntax table, this helps with some edge cases where `[:space:]` is used in a font-lock regex.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
