### PR TITLE
Support def strings with escaped characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#544](https://github.com/clojure-emacs/clojure-mode/issues/544): Fix docstring detection when string contains backslash.
 * [#547](https://github.com/clojure-emacs/clojure-mode/issues/547): Fix font-lock regex for character literals for uppercase chars and other symbols.
 * [#556](https://github.com/clojure-emacs/clojure-mode/issues/556): Fix renaming of ns aliases containing regex characters.
 * [#555](https://github.com/clojure-emacs/clojure-mode/issues/555): Fix ns detection for ns forms with complex metadata.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1007,7 +1007,7 @@ highlighted region)."
                  (not (and (string= "def" firstsym)
                            (save-excursion
                              (goto-char startpos)
-                             (goto-char (+ startpos (length (sexp-at-point)) 2))
+                             (goto-char (end-of-thing 'sexp))
                              (looking-at "[ \r\n\t]*\)")))))
             font-lock-doc-face
           font-lock-string-face))

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -806,7 +806,12 @@ DESCRIPTION is the description of the spec."
 
     ("(def foo \n  \"usage\" \n  \"hello\")"
      (13 19 font-lock-doc-face)
-     (24 30 font-lock-string-face)))
+     (24 30 font-lock-string-face))
+
+    ("(def test-string\n  \"this\\n\n  is\n  my\n  string\")"
+     (20 24 font-lock-string-face)
+     (25 26 (bold font-lock-string-face))
+     (27 46 font-lock-string-face)))
 
   (when-fontifying-it "should handle deftype"
     ("(deftype Foo)"


### PR DESCRIPTION
Fixes #544  and removes irrelevant code from lisp-mode.


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
