### PR TITLE
Fix auto-insertion of spaces in paredit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#565](https://github.com/clojure-emacs/clojure-mode/issues/565): Fix extra spaces being inserted after quote in paredit-mode.
 * [#544](https://github.com/clojure-emacs/clojure-mode/issues/544): Fix docstring detection when string contains backslash.
 * [#547](https://github.com/clojure-emacs/clojure-mode/issues/547): Fix font-lock regex for character literals for uppercase chars and other symbols.
 * [#556](https://github.com/clojure-emacs/clojure-mode/issues/556): Fix renaming of ns aliases containing regex characters.

--- a/Cask
+++ b/Cask
@@ -5,4 +5,5 @@
 
 (development
  (depends-on "s")
- (depends-on "buttercup"))
+ (depends-on "buttercup")
+ (depends-on "paredit"))

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -452,16 +452,13 @@ The command will prompt you to select one of the available sections."
   (interactive)
   (browse-url clojure-style-guide-url))
 
-(defun clojure-space-for-delimiter-p (endp delim)
+(defun clojure-space-for-delimiter-p (endp _delim)
   "Prevent paredit from inserting useless spaces.
 See `paredit-space-for-delimiter-predicates' for the meaning of
 ENDP and DELIM."
-  (and (not (eq (char-before) ?'))
-       (or endp
-           (not (memq delim '(?\" ?\{ ?\()))      ;;  always insert for [
-           (not (or (derived-mode-p 'clojure-mode) ;; FIXME why does this check exist
-                    (derived-mode-p 'cider-repl-mode)))
-           (not (looking-back "\\_<#\\??"))))) ;; auto-gensym syntax foo#
+  (and (not endp)
+       ;; don't insert after ' or # that is part of auto-gensym or reader conditional syntax
+       (not (looking-back "\\_<\\(?:'+\\|#\\??\\)" (point-at-bol)))))
 
 
 (defconst clojure--collection-tag-regexp "#\\(::[a-zA-Z0-9._-]*\\|:?\\([a-zA-Z0-9._-]+/\\)?[a-zA-Z0-9._-]+\\)"

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -457,20 +457,11 @@ The command will prompt you to select one of the available sections."
 See `paredit-space-for-delimiter-predicates' for the meaning of
 ENDP and DELIM."
   (or endp
-      (not (memq delim '(?\" ?{ ?\( )))
-      (not (or (derived-mode-p 'clojure-mode)
+      (not (memq delim '(?\" ?\{ ?\()))  ;;  always insert for [
+      (not (or (derived-mode-p 'clojure-mode) ;; FIXME why does this check exist
                (derived-mode-p 'cider-repl-mode)))
-      (save-excursion
-        (backward-char)
-        (cond ((eq (char-after) ?#)
-               (and (not (bobp))
-                    (or (char-equal ?w (char-syntax (char-before)))
-                        (char-equal ?_ (char-syntax (char-before))))))
-              ((and (eq delim ?\()
-                    (eq (char-after) ??)
-                    (eq (char-before) ?#))
-               nil)
-              (t)))))
+      (not (looking-back "\\_<#\\??")))) ;; auto-gensym syntax foo#
+
 
 (defconst clojure--collection-tag-regexp "#\\(::[a-zA-Z0-9._-]*\\|:?\\([a-zA-Z0-9._-]+/\\)?[a-zA-Z0-9._-]+\\)"
   "Collection reader macro tag regexp.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -456,11 +456,12 @@ The command will prompt you to select one of the available sections."
   "Prevent paredit from inserting useless spaces.
 See `paredit-space-for-delimiter-predicates' for the meaning of
 ENDP and DELIM."
-  (or endp
-      (not (memq delim '(?\" ?\{ ?\()))  ;;  always insert for [
-      (not (or (derived-mode-p 'clojure-mode) ;; FIXME why does this check exist
-               (derived-mode-p 'cider-repl-mode)))
-      (not (looking-back "\\_<#\\??")))) ;; auto-gensym syntax foo#
+  (and (not (eq (char-before) ?'))
+       (or endp
+           (not (memq delim '(?\" ?\{ ?\()))      ;;  always insert for [
+           (not (or (derived-mode-p 'clojure-mode) ;; FIXME why does this check exist
+                    (derived-mode-p 'cider-repl-mode)))
+           (not (looking-back "\\_<#\\??"))))) ;; auto-gensym syntax foo#
 
 
 (defconst clojure--collection-tag-regexp "#\\(::[a-zA-Z0-9._-]*\\|:?\\([a-zA-Z0-9._-]+/\\)?[a-zA-Z0-9._-]+\\)"

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -514,6 +514,7 @@ replacement for `cljr-expand-let`."
     (let ((keymap (or keymap clojure-mode-map)))
       (define-key keymap "{" #'paredit-open-curly)
       (define-key keymap "}" #'paredit-close-curly))
+    (make-local-variable 'paredit-space-for-delimiter-predicates)
     (add-to-list 'paredit-space-for-delimiter-predicates
                  #'clojure-space-for-delimiter-p)
     (add-to-list 'paredit-space-for-delimiter-predicates

--- a/test/clojure-mode-external-interaction-test.el
+++ b/test/clojure-mode-external-interaction-test.el
@@ -84,6 +84,24 @@
       (paredit-open-round))))
 
 
+(describe "Interactions with delete-trailing-whitespace"
+  (when-refactoring-it "should not delete trailing commas"
+    "(def foo
+    \\\"foo\\\": 1,
+    \\\"bar\\\": 2}
+
+(-> m
+  (assoc ,,,
+    :foo 123))"
+    "(def foo
+    \\\"foo\\\": 1,
+    \\\"bar\\\": 2}
+
+(-> m
+  (assoc ,,,
+    :foo 123))"
+    (delete-trailing-whitespace)))
+
 (provide 'clojure-mode-external-interaction-test)
 
 

--- a/test/clojure-mode-external-interaction-test.el
+++ b/test/clojure-mode-external-interaction-test.el
@@ -23,7 +23,7 @@
 (require 'buttercup)
 (require 'paredit)
 
-(describe "Interactions with Paredit"
+(describe "Interactions with Paredit:"
   ;; reuse existing when-refactoring-it macro
   (describe "it should insert a space"
     (when-refactoring-it "before lists"
@@ -56,7 +56,7 @@
       "foo' ()"
       (paredit-mode)
       (paredit-open-round)))
-  (describe "should not insert a space"
+  (describe "it should not insert a space"
     (when-refactoring-it "for anonymous fn syntax"
       "foo #"
       "foo #()"
@@ -81,7 +81,33 @@
       "foo #?"
       "foo #?()"
       (paredit-mode)
-      (paredit-open-round))))
+      (paredit-open-round)))
+  (describe "reader tags"
+    (when-refactoring-it "should insert a space before strings"
+      "#uuid"
+      "#uuid \"\""
+      (paredit-mode)
+      (paredit-doublequote))
+    (when-refactoring-it "should not insert a space before namespaced maps"
+      "#::my-ns"
+      "#::my-ns{}"
+      (paredit-mode)
+      (paredit-open-curly))
+    (when-refactoring-it "should not insert a space before namespaced maps 2"
+      "#::"
+      "#::{}"
+      (paredit-mode)
+      (paredit-open-curly))
+    (when-refactoring-it "should not insert a space before namespaced maps 3"
+      "#:fully.qualified.ns123.-$#.%*+!"
+      "#:fully.qualified.ns123.-$#.%*+!{}"
+      (paredit-mode)
+      (paredit-open-curly))
+    (when-refactoring-it "should not insert a space before tagged vectors"
+      "#tag123.-$#.%*+!"
+      "#tag123.-$#.%*+![]"
+      (paredit-mode)
+      (paredit-open-square))))
 
 
 (describe "Interactions with delete-trailing-whitespace"

--- a/test/clojure-mode-external-interaction-test.el
+++ b/test/clojure-mode-external-interaction-test.el
@@ -1,0 +1,90 @@
+;;; clojure-mode-external-interaction-test.el --- Clojure Mode interactions with external packages test suite  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2014-2020 Bozhidar Batsov <bozhidar@batsov.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'clojure-mode)
+(require 'buttercup)
+(require 'paredit)
+
+(describe "Interactions with Paredit"
+  ;; reuse existing when-refactoring-it macro
+  (describe "it should insert a space"
+    (when-refactoring-it "before lists"
+      "foo"
+      "foo ()"
+      (paredit-mode)
+      (paredit-open-round))
+    (when-refactoring-it "before vectors"
+      "foo"
+      "foo []"
+      (paredit-mode)
+      (paredit-open-square))
+    (when-refactoring-it "before maps"
+      "foo"
+      "foo {}"
+      (paredit-mode)
+      (paredit-open-curly))
+    (when-refactoring-it "before strings"
+      "foo"
+      "foo \"\""
+      (paredit-mode)
+      (paredit-doublequote))
+    (when-refactoring-it "after gensym"
+      "foo#"
+      "foo# ()"
+      (paredit-mode)
+      (paredit-open-round))
+    (when-refactoring-it "after symbols ending with '"
+      "foo'"
+      "foo' ()"
+      (paredit-mode)
+      (paredit-open-round)))
+  (describe "should not insert a space"
+    (when-refactoring-it "for anonymous fn syntax"
+      "foo #"
+      "foo #()"
+      (paredit-mode)
+      (paredit-open-round))
+    (when-refactoring-it "for hash sets"
+      "foo #"
+      "foo #{}"
+      (paredit-mode)
+      (paredit-open-curly))
+    (when-refactoring-it "for regexes"
+      "foo #"
+      "foo #\"\""
+      (paredit-mode)
+      (paredit-doublequote))
+    (when-refactoring-it "for quoted collections"
+      "foo '"
+      "foo '()"
+      (paredit-mode)
+      (paredit-open-round))
+    (when-refactoring-it "for reader conditionals"
+      "foo #?"
+      "foo #?()"
+      (paredit-mode)
+      (paredit-open-round))))
+
+
+(provide 'clojure-mode-external-interaction-test)
+
+
+;;; clojure-mode-external-interaction-test.el ends here

--- a/test/clojure-mode-syntax-test.el
+++ b/test/clojure-mode-syntax-test.el
@@ -75,15 +75,6 @@
         (backward-prefix-chars)
         (expect (bobp))))))
 
-(describe "clojure-no-space-after-tag"
-  (it "should allow allow collection tags"
-    (dolist (tag '("#::ns" "#:ns" "#ns" "#:f.q/ns" "#f.q/ns" "#::"))
-      (with-clojure-buffer tag
-        (expect (clojure-no-space-after-tag nil ?{) :to-be nil)))
-    (dolist (tag '("#$:" "#/f" "#:/f" "#::f.q/ns" "::ns" "::" "#f:ns"))
-      (with-clojure-buffer tag
-        (expect (clojure-no-space-after-tag nil ?{))))))
-
 (describe "fill-paragraph"
 
   (it "should work within comments"


### PR DESCRIPTION
Fixes #565 

The first 3 commits should be squashed together, I just found the original function hard to understand and had to refactor it along the way and then remove what seemed like uneccessary checks.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
