### PR TITLE
Reference :defn in docstring, not defun

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1470,7 +1470,7 @@ the indentation.
 
 The property value can be
 
-- `defun', meaning indent `defun'-style;
+- `:defn', meaning indent `defn'-style;
 - an integer N, meaning indent the first N arguments specially
   like ordinary function arguments and then indent any further
   arguments like a body;


### PR DESCRIPTION
This was changed in
https://github.com/clojure-emacs/clojure-mode/commit/99629deca7938e5a3f359ea3c3896c4a6ca3f5ef
but the docstring wasn't updated


