### PR TITLE
chore: remove command for viewing Clojure Grimoire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#571](https://github.com/clojure-emacs/clojure-mode/issues/571): Remove `project.el` integration.
+* [#574](https://github.com/clojure-emacs/clojure-mode/issues/574): Remove `clojure-view-grimoire` command.
 
 ## 5.12.0 (2020-08-13)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -293,7 +293,6 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
          ["View a Clojure guide" clojure-view-guide]
          ["View a Clojure reference section" clojure-view-reference-section]
          ["View the Clojure cheatsheet" clojure-view-cheatsheet]
-         ["View the Clojure Grimoire" clojure-view-grimoire]
          ["View the Clojure style guide" clojure-view-style-guide])
         "--"
         ["Report a clojure-mode bug" clojure-mode-report-bug]
@@ -435,14 +434,6 @@ The command will prompt you to select one of the available sections."
   "Open the Clojure cheatsheet in your default browser."
   (interactive)
   (browse-url clojure-cheatsheet-url))
-
-(defconst clojure-grimoire-url "https://www.conj.io/"
-  "The URL of the Grimoire community documentation site.")
-
-(defun clojure-view-grimoire ()
-  "Open the Clojure Grimoire in your default browser."
-  (interactive)
-  (browse-url clojure-grimoire-url))
 
 (defconst clojure-style-guide-url "https://guide.clojure.style"
   "The URL of the Clojure style guide.")


### PR DESCRIPTION
The Clojure Grimoire site (conj.io) is no longer operational. Remove the command for browsing that site.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
