### PR TITLE
Fix character font lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#574](https://github.com/clojure-emacs/clojure-mode/issues/574): Remove `clojure-view-grimoire` command.
 * Stop `clojure-sort-ns` from calling `redisplay`.
 * [#584](https://github.com/clojure-emacs/clojure-mode/issues/584): Align to recent `pcase` changes on Emacs master.
+* [#588](https://github.com/clojure-emacs/clojure-mode/pull/588): Fix font-lock for character literals.
 
 ## 5.12.0 (2020-08-13)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -801,8 +801,6 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
                 "\\(\\sw+\\)?" )
        (1 font-lock-keyword-face)
        (2 font-lock-function-name-face nil t))
-      ;; lambda arguments - %, %&, %1, %2, etc
-      ("\\<%[&1-9]?" (0 font-lock-variable-name-face))
       ;; Special forms
       (,(concat
          "("
@@ -862,14 +860,16 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
          "\\>")
        0 font-lock-constant-face)
       ;; Character literals - \1, \a, \newline, \u0000
-      (,(rx "\\" (or any
-                    "newline" "space" "tab" "formfeed" "backspace"
-                    "return"
-                    (: "u" (= 4 (char "0-9a-fA-F")))
-                    (: "o" (repeat 1 3 (char "0-7"))))
-            word-boundary)
-       0 'clojure-character-face)
-
+      (,(rx (group "\\" (or any
+                            "newline" "space" "tab" "formfeed" "backspace"
+                            "return"
+                            (: "u" (= 4 (char "0-9a-fA-F")))
+                            (: "o" (repeat 1 3 (char "0-7")))))
+            (or (not word) word-boundary))
+       1 'clojure-character-face)
+      ;; lambda arguments - %, %&, %1, %2, etc
+      ;; must come after character literals for \% to be handled properly
+      ("\\<%[&1-9]?" (0 font-lock-variable-name-face))
       ;; namespace definitions: (ns foo.bar)
       (,(concat "(\\<ns\\>[ \r\n\t]*"
                 ;; Possibly metadata, shorthand and/or longhand

--- a/test.clj
+++ b/test.clj
@@ -51,7 +51,7 @@
     minnow))
 
 ;; character literals
-[\a \newline \u0032 \/ \+ \,, \;]
+[\a \newline \u0032 \/ \+ \,, \; \( \% \)]
 
 ;; TODO change font-face for sexps starting with @,#
 (comment ;; examples

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -942,6 +942,22 @@ DESCRIPTION is the description of the spec."
     ("\\ク"
      (1 2 clojure-character-face)))
 
+  (when-fontifying-it "should handle characters not by themselves"
+    ("[\\,,]"
+     (1 1 nil)
+     (2 3 clojure-character-face)
+     (4 5 nil))
+
+    ("[\\[]"
+     (1 1 nil)
+     (2 3 clojure-character-face)
+     (4 4 nil)))
+
+  (when-fontifying-it "should handle % character literal"
+    ("#(str \\% %)"
+     (7 8 clojure-character-face)
+     (10 10 font-lock-variable-name-face)))
+
   (when-fontifying-it "should handle referred vars"
     ("foo/var"
      (1 3 font-lock-type-face))


### PR DESCRIPTION
Characters escaped weren't being formatted correctly, as shown by the submitted test.

Example of code that wasn't being formatted:
["text" \\, "other"]
(str \\[ "inside" \\])

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [X] The commits are consistent with our [contribution guidelines][1].
- [X] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [X] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
