### PR TITLE
Rename ns aliases in selected region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#590](https://github.com/clojure-emacs/clojure-mode/pull/590): Extend `clojure-rename-ns-alias` to work on selected regions.
 * [#567](https://github.com/clojure-emacs/clojure-mode/issues/567): Add new commands `clojure-toggle-ignore`, `clojure-toggle-ignore-surrounding-form`, and `clojure-toggle-defun` for inserting/deleting #_ ignore forms.
 * [#582](https://github.com/clojure-emacs/clojure-mode/pull/582): Add `clojure-special-arg-indent-factor` to control special argument indentation.
 

--- a/README.md
+++ b/README.md
@@ -405,9 +405,13 @@ form. If called with a prefix argument slurp the previous n forms.
 
 ### Rename ns alias
 
-`clojure-rename-ns-alias`: Rename an alias inside a namespace declaration.
+`clojure-rename-ns-alias`: Rename an alias inside a namespace declaration, 
+and all of its usages in the buffer
 
 <img width="512" src="/doc/clojure-rename-ns-alias.gif">
+
+If there is an active selected region, only rename usages of aliases within the region, 
+without affecting the namespace declaration.  
 
 ### Add arity to a function
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2723,7 +2723,7 @@ The first match-group is the alias."
   (let ((alias (if alias (regexp-quote alias) clojure--sym-regexp)))
     (concat "#::\\(?1:" alias "\\)[ ,\r\n\t]*{"
             "\\|"
-            "\\(?1:" alias "\\)/")))
+            "\\_<\\(?1:" alias "\\)/")))
 
 (defun clojure--rename-ns-alias-usages (current-alias new-alias beg end)
   "Rename all usages of CURRENT-ALIAS in region BEG to END with NEW-ALIAS."

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2670,38 +2670,6 @@ lists up."
     (insert sexp)
     (clojure--replace-sexps-with-bindings-and-indent)))
 
-(defun clojure-collect-ns-aliases (ns-form)
-  "Collect all namespace aliases in NS-FORM."
-  (with-temp-buffer
-    (delay-mode-hooks
-      (clojure-mode)
-      (insert ns-form)
-      (goto-char (point-min))
-      (let ((end (point-max))
-            (rgx (rx ":as" (+ space)
-                     (group-n 1 (+ (not (in " ,]\n"))))))
-            (res ()))
-        (while (re-search-forward rgx end 'noerror)
-          (unless (or (clojure--in-string-p) (clojure--in-comment-p))
-            (push (match-string-no-properties 1) res)))
-        res))))
-
-(defun clojure--rename-ns-alias-internal (current-alias new-alias)
-  "Rename a namespace alias CURRENT-ALIAS to NEW-ALIAS."
-  (clojure--find-ns-in-direction 'backward)
-  (let ((rgx (concat ":as +" (regexp-quote current-alias) "\\_>"))
-        (bound (save-excursion (forward-list 1) (point))))
-    (when (search-forward-regexp rgx bound t)
-      (replace-match (concat ":as " new-alias))
-      (save-excursion
-        (while (re-search-forward (concat (regexp-quote current-alias) "/") nil t)
-          (when (not (nth 3 (syntax-ppss)))
-            (replace-match (concat new-alias "/")))))
-      (save-excursion
-        (while (re-search-forward (concat "#::" (regexp-quote current-alias) "{") nil t)
-          (replace-match (concat "#::" new-alias "{"))))
-      (message "Successfully renamed alias '%s' to '%s'" current-alias new-alias))))
-
 ;;;###autoload
 (defun clojure-let-backward-slurp-sexp (&optional n)
   "Slurp the s-expression before the let form into the let form.
@@ -2745,21 +2713,80 @@ With a numeric prefix argument the let is introduced N lists up."
   (interactive)
   (clojure--move-to-let-internal (read-from-minibuffer "Name of bound symbol: ")))
 
+
+;;; Renaming ns aliases
+
+(defun clojure--alias-usage-regexp (alias)
+  "Regexp for matching usages of ALIAS in qualified symbols, keywords and maps.
+When nil, match all namespace usages.
+The first match-group is the alias."
+  (let ((alias (if alias (regexp-quote alias) clojure--sym-regexp)))
+    (concat "#::\\(?1:" alias "\\)[ ,\r\n\t]*{"
+            "\\|"
+            "\\(?1:" alias "\\)/")))
+
+(defun clojure--rename-ns-alias-usages (current-alias new-alias beg end)
+  "Rename all usages of CURRENT-ALIAS in region BEG to END with NEW-ALIAS."
+  (let ((rgx (clojure--alias-usage-regexp current-alias)))
+    (save-excursion
+      (goto-char end)
+      (setq end (point-marker))
+      (goto-char beg)
+      (while (re-search-forward rgx end 'noerror)
+        (when (not (clojure--in-string-p)) ;; replace in comments, but not strings
+          (goto-char (match-beginning 1))
+          (delete-region (point) (match-end 1))
+          (insert new-alias))))))
+
+(defun clojure--collect-ns-aliases (beg end ns-form-p)
+  "Collect all aliases between BEG and END.
+When NS-FORM-P is non-nil, treat the region as a ns form
+and pick up aliases from [... :as alias] forms,
+otherwise pick up alias usages from keywords / symbols."
+  (let ((res ()))
+    (save-excursion
+      (let ((rgx (if ns-form-p
+                     (rx ":as" (+ space)
+                         (group-n 1 (+ (not (in " ,]\n")))))
+                   (clojure--alias-usage-regexp nil))))
+        (goto-char beg)
+        (while (re-search-forward rgx end 'noerror)
+          (unless (or (clojure--in-string-p) (clojure--in-comment-p))
+            (cl-pushnew (match-string-no-properties 1) res
+                        :test #'equal)))
+        (reverse res)))))
+
+(defun clojure--rename-ns-alias-internal (current-alias new-alias)
+  "Rename a namespace alias CURRENT-ALIAS to NEW-ALIAS.
+Assume point is at the start of ns form."
+  (clojure--find-ns-in-direction 'backward)
+  (let ((rgx (concat ":as +" (regexp-quote current-alias) "\\_>"))
+        (bound (save-excursion (forward-list 1) (point-marker))))
+    (when (search-forward-regexp rgx bound t)
+      (replace-match (concat ":as " new-alias))
+      (clojure--rename-ns-alias-usages current-alias new-alias bound (point-max)))))
+
 ;;;###autoload
 (defun clojure-rename-ns-alias ()
-  "Rename a namespace alias."
+  "Rename a namespace alias.
+If a region is active, only pick up and rename aliases within the region."
   (interactive)
-  (save-excursion
-    (clojure--find-ns-in-direction 'backward)
-    (let* ((current-alias (completing-read "Current alias: "
-                                           (clojure-collect-ns-aliases
-                                            (thing-at-point 'list))))
-           (rgx (concat ":as +" (regexp-quote current-alias) "\\_>"))
-           (bound (save-excursion (forward-list 1) (point))))
-      (if (save-excursion (search-forward-regexp rgx bound t))
-          (let ((new-alias (read-from-minibuffer "New alias: ")))
-            (clojure--rename-ns-alias-internal current-alias new-alias))
-        (message "Cannot find namespace alias: '%s'" current-alias)))))
+  (if (use-region-p)
+      (let* ((beg (region-beginning))
+             (end (region-end))
+             (current-alias (completing-read "Current alias: "
+                                             (clojure--collect-ns-aliases
+                                              beg end nil)))
+             (new-alias (read-from-minibuffer (format "Replace %s with: " current-alias))))
+        (clojure--rename-ns-alias-usages current-alias new-alias beg end))
+    (save-excursion
+      (clojure--find-ns-in-direction 'backward)
+      (let* ((bounds (bounds-of-thing-at-point 'list))
+             (current-alias (completing-read "Current alias: "
+                                             (clojure--collect-ns-aliases
+                                              (car bounds) (cdr bounds) t)))
+             (new-alias (read-from-minibuffer (format "Replace %s with: " current-alias))))
+        (clojure--rename-ns-alias-internal current-alias new-alias)))))
 
 (defun clojure--add-arity-defprotocol-internal ()
   "Add an arity to a signature inside a defprotocol.


### PR DESCRIPTION
When copying code from other sources, the conventions for aliasing namespaces may be different (eg. `str` vs `string` for clojure.string) and one has to manually search and replace these aliases.

Since there was already a `clojure-rename-ns-alias` command with most of the relevant logic, I extended it to be able to rename aliases in a selected region. In that case, it will not touch the ns form at all and only pick up aliases from the region.

I also cleaned up the code a bit from my previous PR here, moving the ns-alias related functions together and renaming `clojure-collect-ns-aliases` with double dashes (there was really no reason for it to be public in the first place). 

The API could be changed to introduce another command instead of doing region-active DWIM on `clojure-rename-ns-alias`. But in practice I find that such renaming usually involves multiple (selected) forms, so a command that works on top-level forms probably isn't that useful.

Will update the changelog and readme after details are confirmed :) 

Thanks!



-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
