### PR TITLE
[Fix #593] clojure-find-ns breaks if the ns form is preceded by ws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+* [#593] clojure-find-ns breaks if the ns form is preceded by whitespace
+
 ## 5.13.0 (2021-05-05)
 
 ### New features

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1873,7 +1873,7 @@ content) are considered part of the preceding sexp."
 (make-obsolete-variable 'clojure-namespace-name-regex 'clojure-namespace-regexp "5.12.0")
 
 (defconst clojure-namespace-regexp
-  (rx line-start "(" (? "clojure.core/") (or "in-ns" "ns" "ns+") symbol-end))
+  (rx line-start (zero-or-more whitespace) "(" (? "clojure.core/") (or "in-ns" "ns" "ns+") symbol-end))
 
 (defcustom clojure-cache-ns nil
   "Whether to cache the results of `clojure-find-ns'.

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -61,6 +61,8 @@
   (it "should find common namespace declarations"
     (with-clojure-buffer "(ns foo)"
       (expect (clojure-find-ns) :to-equal "foo"))
+    (with-clojure-buffer " (ns foo)"
+      (expect (clojure-find-ns) :to-equal "foo"))
     (with-clojure-buffer "(ns
     foo)"
       (expect (clojure-find-ns) :to-equal "foo"))


### PR DESCRIPTION
Problem was that the regexp here expected (ns form to start right in the
beginning of the line. I added zero or more whitespace in the beginning which
corrects the issue.

Adds also a unit test which covers the issue.


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [ x] The commits are consistent with our [contribution guidelines][1].
- [ x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
