### PR TITLE
Add clojure-directory-prefixes customisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+### New features
+
 * Allow additional directories, beyond the default `clj[sc]`, to be correctly formulated by `clojure-expected-ns` via new `defcustom` entitled `clojure-directory-prefixes`
 
 ## 5.13.0 (2021-05-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-* Allow additional eliding beyond just `clj[sc]` in `clojure-expected-ns` via new `defcustom` entitled `clojure-elided-prefixes-ns`
+* Allow additional directories, beyond the default `clj[sc]`, to be correctly formulated by `clojure-expected-ns` via new `defcustom` entitled `clojure-directory-prefixes`
 
 ## 5.13.0 (2021-05-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Allow additional eliding beyond just `clj[sc]` in `clojure-expected-ns` via new `defcustom` entitled `clojure-elided-prefixes-ns`
+
 ## 5.13.0 (2021-05-05)
 
 ### New features

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -196,9 +196,9 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
           (and (listp value)
                (cl-every 'stringp value))))
 
-(defcustom clojure-elided-prefixes-ns
-  '()
-  "A list of additional regexp prefixes that are elided when formulating ns."
+(defcustom clojure-directory-prefixes
+  '("\\`clj[scx]?\\.")
+  "A list of directory prefixes used by clojure-expected-ns to formulate correct ns."
   :type '(repeat string)
   :package-version '(clojure-mode . "5.0.0")
   :safe (lambda (value)
@@ -1770,9 +1770,8 @@ If PATH is nil, use the path to the file backing the current buffer."
          (sans-file-sep (mapconcat 'identity (cdr (split-string sans-file-type "/")) "."))
          (sans-underscores (replace-regexp-in-string "_" "-" sans-file-sep)))
     ;; Drop prefix from ns for projects with structure src/{clj,cljs,cljc}
-    (cl-reduce (lambda (a x)
-                 (replace-regexp-in-string x "" a))
-               (add-to-list 'clojure-elided-prefixes-ns "\\`clj[scx]?\\.")
+    (cl-reduce (lambda (a x) (replace-regexp-in-string x "" a))
+               'clojure-directory-prefixes
                :initial-value sans-underscores)))
 
 (defun clojure-insert-ns-form-at-point ()

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -196,6 +196,15 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
           (and (listp value)
                (cl-every 'stringp value))))
 
+(defcustom clojure-elided-prefixes-ns
+  '()
+  "A list of additional regexp prefixes that are elided when formulating ns."
+  :type '(repeat string)
+  :package-version '(clojure-mode . "5.0.0")
+  :safe (lambda (value)
+          (and (listp value)
+               (cl-every 'stringp value))))
+
 (defcustom clojure-project-root-function #'clojure-project-root-path
   "Function to locate clojure project root directory."
   :type 'function
@@ -1761,7 +1770,10 @@ If PATH is nil, use the path to the file backing the current buffer."
          (sans-file-sep (mapconcat 'identity (cdr (split-string sans-file-type "/")) "."))
          (sans-underscores (replace-regexp-in-string "_" "-" sans-file-sep)))
     ;; Drop prefix from ns for projects with structure src/{clj,cljs,cljc}
-    (replace-regexp-in-string "\\`clj[scx]?\\." "" sans-underscores)))
+    (cl-reduce (lambda (a x)
+                 (replace-regexp-in-string x "" a))
+               (add-to-list 'clojure-elided-prefixes-ns "\\`clj[scx]?\\.")
+               :initial-value sans-underscores)))
 
 (defun clojure-insert-ns-form-at-point ()
   "Insert a namespace form at point."

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1771,7 +1771,7 @@ If PATH is nil, use the path to the file backing the current buffer."
          (sans-underscores (replace-regexp-in-string "_" "-" sans-file-sep)))
     ;; Drop prefix from ns for projects with structure src/{clj,cljs,cljc}
     (cl-reduce (lambda (a x) (replace-regexp-in-string x "" a))
-               'clojure-directory-prefixes
+               clojure-directory-prefixes
                :initial-value sans-underscores)))
 
 (defun clojure-insert-ns-form-at-point ()

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -198,9 +198,9 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
 
 (defcustom clojure-directory-prefixes
   '("\\`clj[scx]?\\.")
-  "A list of directory prefixes used by clojure-expected-ns to formulate correct ns."
+  "A list of directory prefixes used by `clojure-expected-ns' to formulate correct ns."
   :type '(repeat string)
-  :package-version '(clojure-mode . "5.0.0")
+  :package-version '(clojure-mode . "5.14.0")
   :safe (lambda (value)
           (and (listp value)
                (cl-every 'stringp value))))

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -198,7 +198,8 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
 
 (defcustom clojure-directory-prefixes
   '("\\`clj[scx]?\\.")
-  "A list of directory prefixes used by `clojure-expected-ns' to formulate correct ns."
+  "A list of directory prefixes used by `clojure-expected-ns'
+to formulate correct ns."
   :type '(repeat string)
   :package-version '(clojure-mode . "5.14.0")
   :safe (lambda (value)


### PR DESCRIPTION
This change enables customisation of the auto-inserted `ns` form on new file creation. It reflects the needs of larger code projects with atypical folder structures, as for example shown below:

```
{/src,/test}
  /bb
  /clj
  /cljc
  /cljs
  /common
```
where `{:paths ["src/clj" "src/cljc" "src/cljs" "src/bb" "src/common" ...] ...}` are specified accordingly in the `deps.edn`.

With the following customisation in `dir-locals.el`, or otherwise configured:

```elisp
((nil
  . ((clojure-directory-prefixes . ("\\`clj[scx]?\\." "\\`bb\\." "\\`common\\.")))))
 ```

The correct namespace is auto-inserted for new `clj[cs]` files created within `src/bb` and `src/common`.

-----------------

- [X] The commits are consistent with our contribution guidelines.
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [X] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [X] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
