### PR TITLE
Mark put-clojure-indent safe for use in LocalVariables, .dir-locals.el, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ compile: elpa
 	$(CASK) build
 
 clean:
-	rm -f $(OBJS)
+	rm -f $(OBJS) clojure-mode-autoloads.el
 
 test: $(PKGDIR)
 	$(CASK) exec buttercup

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ test-bytecomp: $(SRCS:.el=.elc-test)
 
 %.elc-test: %.el elpa
 	$(CASK) exec $(EMACS) --no-site-file --no-site-lisp --batch \
-		-l test/clojure-mode-bytecomp-warnings.el $
+		-l test/clojure-mode-bytecomp-warnings.el $<

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1845,6 +1845,9 @@ If PATH is nil, use the path to the file backing the current buffer."
   (goto-char (point-min))
   (clojure-insert-ns-form-at-point))
 
+(defvar-local clojure-cached-ns nil
+  "A buffer ns cache used to speed up ns-related operations.")
+
 (defun clojure-update-ns ()
   "Update the namespace of the current buffer.
 Useful if a file has been renamed."
@@ -1956,9 +1959,6 @@ the cached value will be updated automatically."
   :type 'boolean
   :safe #'booleanp
   :package-version '(clojure-mode . "5.8.0"))
-
-(defvar-local clojure-cached-ns nil
-  "A buffer ns cache used to speed up ns-related operations.")
 
 (defun clojure--find-ns-in-direction (direction)
   "Return the nearest namespace in a specific DIRECTION.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -68,6 +68,7 @@
 (require 'cl-lib)
 (require 'imenu)
 (require 'newcomment)
+(require 'thingatpt)
 (require 'align)
 (require 'subr-x)
 (require 'lisp-mnt)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -480,7 +480,7 @@ This includes #fully.qualified/my-ns[:kw val] and #::my-ns{:kw
 val} as of Clojure 1.9.")
 
 (make-obsolete-variable 'clojure--collection-tag-regexp nil "5.12.0")
-(make-obsolete #'clojure-no-space-after-tag #'clojure-space-for-delimiter-p "5.12.0")
+(make-obsolete 'clojure-no-space-after-tag 'clojure-space-for-delimiter-p "5.12.0")
 
 (declare-function paredit-open-curly "ext:paredit" t t)
 (declare-function paredit-close-curly "ext:paredit" t t)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -486,6 +486,16 @@ val} as of Clojure 1.9.")
 (declare-function paredit-close-curly "ext:paredit" t t)
 (declare-function paredit-convolute-sexp "ext:paredit")
 
+(defvar clojure--let-regexp
+  "\(\\(when-let\\|if-let\\|let\\)\\(\\s-*\\|\\[\\)"
+  "Regexp matching let like expressions, i.e. \"let\", \"when-let\", \"if-let\".
+
+The first match-group is the let expression.
+
+The second match-group is the whitespace or the opening square
+bracket if no whitespace between the let expression and the
+bracket.")
+
 (defun clojure--replace-let-bindings-and-indent (&rest _)
   "Replace let bindings and indent."
   (save-excursion
@@ -2541,16 +2551,6 @@ See: https://github.com/clojure-emacs/clj-refactor.el/wiki/cljr-cycle-if"
       (insert ")"))))
 
 ;;; let related stuff
-
-(defvar clojure--let-regexp
-  "\(\\(when-let\\|if-let\\|let\\)\\(\\s-*\\|\\[\\)"
-  "Regexp matching let like expressions, i.e. \"let\", \"when-let\", \"if-let\".
-
-The first match-group is the let expression.
-
-The second match-group is the whitespace or the opening square
-bracket if no whitespace between the let expression and the
-bracket.")
 
 (defun clojure--goto-let ()
   "Go to the beginning of the nearest let form."

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1133,7 +1133,7 @@ will align the values like this:
 (defconst clojure--align-separator-newline-regexp "^ *$")
 
 (defcustom clojure-align-separator clojure--align-separator-newline-regexp
-  "The separator that will be passed to `align-region' when performing vertical alignment."
+  "Separator passed to `align-region' when performing vertical alignment."
   :package-version '(clojure-mode . "5.10")
   :type `(choice (const :tag "Make blank lines prevent vertical alignment from happening."
                         ,clojure--align-separator-newline-regexp)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1554,6 +1554,53 @@ This function also returns nil meaning don't specify the indentation."
   "Instruct `clojure-indent-function' to indent the body of SYM by INDENT."
   (put sym 'clojure-indent-function indent))
 
+(defun clojure--maybe-quoted-symbol-p (x)
+  "Check that X is either a symbol or a quoted symbol like :foo or 'foo."
+  (or (symbolp x)
+      (and (listp x)
+           (= 2 (length x))
+           (eq 'quote (car x))
+           (symbolp (cadr x)))))
+
+(defun clojure--valid-unquoted-indent-spec-p (spec)
+  "Check that the indentation SPEC is valid.
+Validate it with respect to
+https://docs.cider.mx/cider/indent_spec.html e.g. (2 :form
+:form (1)))."
+  (or (integerp spec)
+      (memq spec '(:form :defn))
+      (and (listp spec)
+           (not (null spec))
+           (or (integerp (car spec))
+               (memq (car spec) '(:form :defn)))
+           (seq-every-p 'clojure--valid-unquoted-indent-spec-p (cdr spec)))))
+
+(defun clojure--valid-indent-spec-p (spec)
+  "Check that the indentation SPEC (quoted if a list) is valid.
+Validate it with respect to
+https://docs.cider.mx/cider/indent_spec.html e.g. (2 :form
+:form (1)))."
+  (or (integerp spec)
+      (and (keywordp spec) (memq spec '(:form :defn)))
+      (and (listp spec)
+           (= 2 (length spec))
+           (eq 'quote (car spec))
+           (clojure--valid-unquoted-indent-spec-p (cadr spec)))))
+
+(defun clojure--valid-put-clojure-indent-call-p (exp)
+  "Check that EXP is a valid `put-clojure-indent' expression.
+For example: (put-clojure-indent 'defrecord '(2 :form :form (1))."
+  (unless (and (listp exp)
+               (= 3 (length exp))
+               (eq 'put-clojure-indent (nth 0 exp))
+               (clojure--maybe-quoted-symbol-p (nth 1 exp))
+               (clojure--valid-indent-spec-p (nth 2 exp)))
+    (error "Unrecognized put-clojure-indent call: %s" exp))
+  t)
+
+(put 'put-clojure-indent 'safe-local-eval-function
+     'clojure--valid-put-clojure-indent-call-p)
+
 (defmacro define-clojure-indent (&rest kvs)
   "Call `put-clojure-indent' on a series, KVS."
   `(progn

--- a/test/clojure-mode-safe-eval-test.el
+++ b/test/clojure-mode-safe-eval-test.el
@@ -1,0 +1,74 @@
+;;; clojure-mode-safe-eval-test.el --- Clojure Mode: safe eval test suite  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2014-2021 Bozhidar Batsov <bozhidar@batsov.com>
+;; Copyright (C) 2021 Rob Browning <rlb@defaultvalue.org>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; The safe eval test suite of Clojure Mode
+
+;;; Code:
+(require 'clojure-mode)
+(require 'buttercup)
+
+(describe "put-clojure-indent safe-local-eval-function property"
+  (it "should be set to clojure--valid-put-clojure-indent-call-p"
+      (expect (get 'put-clojure-indent 'safe-local-eval-function)
+              :to-be 'clojure--valid-put-clojure-indent-call-p)))
+
+(describe "clojure--valid-put-clojure-indent-call-p"
+  (it "should approve valid forms"
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo 1)))
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo :defn)))
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo :form)))
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(1))))
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(:defn))))
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(:form))))
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(1 1))))
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(2 :form :form (1))))))
+  (it "should reject invalid forms"
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 1 1))
+              :to-throw 'error)
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo :foo))
+              :to-throw 'error)
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo (:defn)))
+              :to-throw 'error)
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(:foo)))
+              :to-throw 'error)
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(1 :foo)))
+              :to-throw 'error)
+      (expect (clojure--valid-put-clojure-indent-call-p
+               '(put-clojure-indent 'foo '(1 "foo")))
+              :to-throw 'error)))
+
+(provide 'clojure-mode-safe-eval-test)
+
+;;; clojure-mode-safe-eval-test.el ends here


### PR DESCRIPTION
Add a put-clojure-indent form validator and attach it as a
safe-local-eval-function property so that safe invocations won't
trigger open-file prompts when used in local variables, or when added
to .dir-locals.el like this:
```elisp
  ((clojure-mode
    (eval . (put-clojure-indent 'defrecord '(2 :form :form (1))))))
```
For now, only support specs specified as lists, not vectors.

-----------------

This work assumes that we don't want to rely on any existing validation, and so attempts to perform thorough validation up front.  Also happy to make further changes, but thought I'd post what I have, to see if I'm on a reasonable track.