### PR TITLE
Add refactoring command for converting #() shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Allow additional directories, beyond the default `clj[sc]`, to be correctly formulated by `clojure-expected-ns` via new `defcustom` entitled `clojure-directory-prefixes`
 * Recognize babashka projects (identified by the presence of `bb.edn`).
+* [#601](https://github.com/clojure-emacs/clojure-mode/pull/601): Add new command `clojure-promote-fn-literal` for converting #() function literals to `fn` form 
 
 ### Changes
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -263,6 +263,8 @@ The prefixes are used to generate the correct namespace."
     (define-key map (kbd "C--") #'clojure-toggle-ignore)
     (define-key map (kbd "_") #'clojure-toggle-ignore-surrounding-form)
     (define-key map (kbd "C-_") #'clojure-toggle-ignore-surrounding-form)
+    (define-key map (kbd "P") #'clojure-promote-fn-literal)
+    (define-key map (kbd "C-P") #'clojure-promote-fn-literal)
     map)
   "Keymap for Clojure refactoring commands.")
 (fset 'clojure-refactor-map clojure-refactor-map)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2807,7 +2807,7 @@ END marks the end of the fn expression"
   (when-let (beg (clojure-string-start))
     (goto-char beg))
   (if (or (looking-at-p "#(")
-          (forward-char 1)
+          (ignore-errors (forward-char 1))
           (re-search-backward "#(" (save-excursion (beginning-of-defun) (point)) 'noerror))
       (let* ((end (save-excursion (clojure-forward-logical-sexp) (point-marker)))
              (argspec (clojure--gather-shorthand-args))

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -286,6 +286,7 @@ The prefixes are used to generate the correct namespace."
         ["Toggle #_ ignore form" clojure-toggle-ignore]
         ["Toggle #_ ignore of surrounding form" clojure-toggle-ignore-surrounding-form]
         ["Add function arity" clojure-add-arity]
+        ["Promote #() fn literal" clojure-promote-fn-literal]
         ("ns forms"
          ["Insert ns form at the top" clojure-insert-ns-form]
          ["Insert ns form here" clojure-insert-ns-form-at-point]

--- a/test/clojure-mode-convert-fn-test.el
+++ b/test/clojure-mode-convert-fn-test.el
@@ -1,0 +1,72 @@
+;;; clojure-mode-convert-fn-test.el --- Clojure Mode: convert fn syntax -*- lexical-binding: t; -*-
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for clojure-convert-shorthand-fn
+
+;;; Code:
+
+(require 'clojure-mode)
+(require 'buttercup)
+
+(describe "clojure-convert-shorthand-fn"
+  :var (names)
+
+  (before-each
+    (spy-on 'read-string
+            :and-call-fake (lambda (_) (or (pop names) (error "")))))
+
+  (when-refactoring-it "should convert 0-arg fns"
+    "#(rand)"
+    "(fn [] (rand))"
+    (clojure-convert-shorthand-fn))
+
+  (when-refactoring-it "should convert 1-arg fns"
+    "#(= % 1)"
+    "(fn [x] (= x 1))"
+    (setq names '("x"))
+    (clojure-convert-shorthand-fn))
+
+  (when-refactoring-it "should convert 2-arg fns"
+    "#(conj (pop %1) (assoc (peek %1) %2 (* %2 %2)))"
+    "(fn [acc x] (conj (pop acc) (assoc (peek acc) x (* x x))))"
+    (setq names '("acc" "x"))
+    (clojure-convert-shorthand-fn))
+
+  (when-refactoring-it "should convert variadic fns"
+    ;; from https://hypirion.com/musings/swearjure
+    "#(* (`[~@%&] (+))
+   ((% (+)) % (- (`[~@%&] (+)) (*))))"
+    "(fn [v & vs] (* (`[~@vs] (+))
+   ((v (+)) v (- (`[~@vs] (+)) (*)))))"
+    (setq names '("v" "vs"))
+    (clojure-convert-shorthand-fn))
+
+  (when-refactoring-it "should ignore strings and comments"
+    "#(format \"%2\" ;; FIXME: %2 is an illegal specifier
+   %7) "
+    "(fn [_ _ _ _ _ _ id] (format \"%2\" ;; FIXME: %2 is an illegal specifier
+   id)) "
+    (setq names '("_" "_" "_" "_" "_" "_" "id"))
+    (clojure-convert-shorthand-fn)))
+
+
+(provide 'clojure-mode-convert-fn-test)
+
+
+;;; clojure-mode-convert-fn-test.el ends here

--- a/test/clojure-mode-promote-fn-literal-test.el
+++ b/test/clojure-mode-promote-fn-literal-test.el
@@ -1,4 +1,4 @@
-;;; clojure-mode-convert-fn-test.el --- Clojure Mode: convert fn syntax -*- lexical-binding: t; -*-
+;;; clojure-mode-promote-fn-literal-test.el --- Clojure Mode: convert fn syntax -*- lexical-binding: t; -*-
 
 ;; This file is not part of GNU Emacs.
 
@@ -17,14 +17,14 @@
 
 ;;; Commentary:
 
-;; Tests for clojure-convert-shorthand-fn
+;; Tests for clojure-promote-fn-literal
 
 ;;; Code:
 
 (require 'clojure-mode)
 (require 'buttercup)
 
-(describe "clojure-convert-shorthand-fn"
+(describe "clojure-promote-fn-literal"
   :var (names)
 
   (before-each
@@ -34,19 +34,19 @@
   (when-refactoring-it "should convert 0-arg fns"
     "#(rand)"
     "(fn [] (rand))"
-    (clojure-convert-shorthand-fn))
+    (clojure-promote-fn-literal))
 
   (when-refactoring-it "should convert 1-arg fns"
     "#(= % 1)"
     "(fn [x] (= x 1))"
     (setq names '("x"))
-    (clojure-convert-shorthand-fn))
+    (clojure-promote-fn-literal))
 
   (when-refactoring-it "should convert 2-arg fns"
-    "#(conj (pop %1) (assoc (peek %1) %2 (* %2 %2)))"
+    "#(conj (pop %) (assoc (peek %1) %2 (* %2 %2)))"
     "(fn [acc x] (conj (pop acc) (assoc (peek acc) x (* x x))))"
     (setq names '("acc" "x"))
-    (clojure-convert-shorthand-fn))
+    (clojure-promote-fn-literal))
 
   (when-refactoring-it "should convert variadic fns"
     ;; from https://hypirion.com/musings/swearjure
@@ -55,7 +55,7 @@
     "(fn [v & vs] (* (`[~@vs] (+))
    ((v (+)) v (- (`[~@vs] (+)) (*)))))"
     (setq names '("v" "vs"))
-    (clojure-convert-shorthand-fn))
+    (clojure-promote-fn-literal))
 
   (when-refactoring-it "should ignore strings and comments"
     "#(format \"%2\" ;; FIXME: %2 is an illegal specifier
@@ -63,10 +63,10 @@
     "(fn [_ _ _ _ _ _ id] (format \"%2\" ;; FIXME: %2 is an illegal specifier
    id)) "
     (setq names '("_" "_" "_" "_" "_" "_" "id"))
-    (clojure-convert-shorthand-fn)))
+    (clojure-promote-fn-literal)))
 
 
 (provide 'clojure-mode-convert-fn-test)
 
 
-;;; clojure-mode-convert-fn-test.el ends here
+;;; clojure-mode-promote-fn-literal-test.el ends here


### PR DESCRIPTION
`M-x clojure-convert-shorthand-fn` turns the closest #() before point into a regular (fn ...) form. If there are any `%` arguments it prompts interactively for the arg names.
Useful for fixing nested #() forms and general refactoring for readability. (I believe the reverse refactoring is much less necessary in practice) 

## Keybindings:
Not implemented yet, but I think "convert function" ( prefix + `cf` / `fc`)  makes sense in the `clj-refactor` package, as well as here in the default `clojure-refactor-map` as the single key bindings `#` `f` and `c` are all taken.



-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
