### PR TITLE
Add `(require 'seq)`

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1586,7 +1586,7 @@ https://docs.cider.mx/cider/indent_spec.html e.g. (2 :form
            (not (null spec))
            (or (integerp (car spec))
                (memq (car spec) '(:form :defn)))
-           (seq-every-p 'clojure--valid-unquoted-indent-spec-p (cdr spec)))))
+           (cl-every 'clojure--valid-unquoted-indent-spec-p (cdr spec)))))
 
 (defun clojure--valid-indent-spec-p (spec)
   "Check that the indentation SPEC (quoted if a list) is valid.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -73,6 +73,7 @@
 (require 'align)
 (require 'subr-x)
 (require 'lisp-mnt)
+(require 'seq)
 
 (declare-function lisp-fill-paragraph  "lisp-mode" (&optional justify))
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -73,7 +73,6 @@
 (require 'align)
 (require 'subr-x)
 (require 'lisp-mnt)
-(require 'seq)
 
 (declare-function lisp-fill-paragraph  "lisp-mode" (&optional justify))
 


### PR DESCRIPTION
I add `(require 'seq)`, since `seq-every-p` is not autoloaded.
When it is installed by package.el, its absence causes byte-compile warning: 
```
In end of data:
clojure-mode.el:3019:1:Warning: the function ‘seq-every-p’ is not known to be
    defined.
```

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
