### PR TITLE
Support clojure-dart files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#615](https://github.com/clojure-emacs/clojure-mode/issues/615): Support clojure-dart files.
+
 ## 5.14.0 (2022-03-07)
 
 ### New features

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -200,7 +200,7 @@ Out-of-the box `clojure-mode' understands lein, boot, gradle,
                (cl-every 'stringp value))))
 
 (defcustom clojure-directory-prefixes
-  '("\\`clj[scx]?\\.")
+  '("\\`clj[scxd]?\\.")
   "A list of directory prefixes used by `clojure-expected-ns'.
 The prefixes are used to generate the correct namespace."
   :type '(repeat string)
@@ -3070,7 +3070,7 @@ With universal argument \\[universal-argument], act on the \"top-level\" form."
 ;;;###autoload
 (progn
   (add-to-list 'auto-mode-alist
-               '("\\.\\(clj\\|dtm\\|edn\\)\\'" . clojure-mode))
+               '("\\.\\(clj\\|cljd\\|dtm\\|edn\\)\\'" . clojure-mode))
   (add-to-list 'auto-mode-alist '("\\.cljc\\'" . clojurec-mode))
   (add-to-list 'auto-mode-alist '("\\.cljs\\'" . clojurescript-mode))
   ;; boot build scripts are Clojure source files


### PR DESCRIPTION
[Fix #615].

Adds minimal support to cljd files (clojure-dart) as a clojure derived major mode (clojuredart-mode).

-----------------

- [X] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [X] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [X] You've updated the changelog (if adding/changing user-visible functionality).
- [X] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
