### PR TITLE
Remove needless quote of choice values

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -141,10 +141,10 @@ to indent function forms.
           merge
           some-coll)"
   :safe #'symbolp
-  :type '(choice (const :tag "Same as `lisp-mode'" 'always-align)
-                 (const :tag "Indent like a macro body" 'always-indent)
+  :type '(choice (const :tag "Same as `lisp-mode'" always-align)
+                 (const :tag "Indent like a macro body" always-indent)
                  (const :tag "Indent like a macro body unless first arg is on the same line"
-                        'align-arguments))
+                        align-arguments))
   :package-version '(clojure-mode . "5.2.0"))
 
 (defcustom clojure-use-backtracking-indent t
@@ -1143,7 +1143,7 @@ will align the values like this:
   :type `(choice (const :tag "Make blank lines prevent vertical alignment from happening."
                         ,clojure--align-separator-newline-regexp)
                  (other :tag "Allow blank lines to happen within a vertically-aligned expression."
-                        'entire)))
+                        entire)))
 
 (defcustom clojure-align-reader-conditionals nil
   "Whether to align reader conditionals, as if they were maps."


### PR DESCRIPTION
The customize menu of those variables does not work. Because default value `'always-align` does not match against any choice values. (The choice list is already quoted so for example  `'always-align` in the list means `''always-align`). 

Customize menu of original code is as below. It shows `(mismatch)` due to the above reason. And `[Value Menu]` does not display.

![image](https://user-images.githubusercontent.com/554281/177525892-07972340-6564-4f15-9474-5da7e615eb6c.png)

This PR version is below. There is a `[Value Menu]` and there is no `(mismatch)`.

![image](https://user-images.githubusercontent.com/554281/177526014-9fce1e02-14da-4542-8411-ecf1473a52fb.png)

BTW, development Emacs(29.0.50) warns this kind of mistakes by byte-compiling.

```
clojure-mode.el:101:12: Warning: defcustom for ‘clojure-indent-style’ has
    syntactically odd type ‘'(choice (const :tag Same as `lisp-mode'
    'always-align) (const :tag Indent like a macro body 'always-indent) (const
    :tag Indent like a macro body unless first arg is on the same line
    'align-arguments))’
```

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
