### PR TITLE
[Fix #625] Fix imenu displaying metadata instead of var name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#625](https://github.com/clojure-emacs/clojure-mode/issues/625): Fix metadata being displayed in imenu instead of var name
+
 ## 5.15.0 (2022-07-19)
 
 ### Changes

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -757,7 +757,7 @@ Called by `imenu--generic-function'."
             (when (char-equal ?^ (char-after def-beg))
               ;; move to the beginning of next sexp
               (progn (forward-sexp) (backward-sexp)))
-            (when (or (not (char-equal ?^ (char-after (point))))
+            (when (or (not (char-equal ?^ (char-after def-beg)))
                       (and (char-equal ?^ (char-after (point))) (= def-beg (point))))
               (setq found? t)
               (when (string= deftype "defmethod")

--- a/test.clj
+++ b/test.clj
@@ -227,6 +227,10 @@
 ;; definitions with metadata only don't cause freezing
 (def ^String)
 
+(defmulti multi (fn [a _] a))
+(defmethod multi :test [_ b] b)
+(defmethod multi :best [_ b] b)
+
 (defn ^String reverse
   "Returns s with its characters reversed."
   {:added "1.2"}


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/clojure-mode/issues/625

Fix incorrect bounds for var name being captured in `clojure-match-next-def` when metadata is present in definition. [Context](https://github.com/clojure-emacs/clojure-mode/issues/625#issuecomment-1198600423)

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
