### PR TITLE
[Fix #581] Fix font locking for keywords starting with a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#581](https://github.com/clojure-emacs/clojure-mode/issues/581): Fix font locking not working for keywords starting with a number
+
 ## 5.15.1 (2022-07-30)
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -780,6 +780,15 @@ definition of 'macros': URL `http://git.io/vRGLD'.")
     (concat "[^" clojure--sym-forbidden-1st-chars "][^" clojure--sym-forbidden-rest-chars "]*")
     "A regexp matching a Clojure symbol or namespace alias.
 Matches the rule `clojure--sym-forbidden-1st-chars' followed by
+any number of matches of `clojure--sym-forbidden-rest-chars'.")
+  (defconst clojure--keyword-sym-forbidden-1st-chars
+    (concat clojure--sym-forbidden-rest-chars ":'")
+    "A list of chars that a Clojure keyword symbol cannot start with.")
+  (defconst clojure--keyword-sym-regexp
+    (concat "[^" clojure--keyword-sym-forbidden-1st-chars "]"
+            "[^" clojure--sym-forbidden-rest-chars "]*")
+    "A regexp matching a Clojure keyword name or keyword namespace.
+Matches the rule `clojure--keyword-sym-forbidden-1st-chars' followed by
 any number of matches of `clojure--sym-forbidden-rest-chars'."))
 
 (defconst clojure-font-lock-keywords
@@ -974,13 +983,14 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
       ;; TODO dedupe the code for matching of keywords, type-hints and unmatched symbols
 
       ;; keywords: {:oneword/ve/yCom|pLex.stu-ff 0}
-      (,(concat "\\(:\\{1,2\\}\\)\\(" clojure--sym-regexp "?\\)\\(/\\)\\(" clojure--sym-regexp "\\)")
+      (,(concat "\\(:\\{1,2\\}\\)\\(" clojure--keyword-sym-regexp "?\\)\\(/\\)"
+                "\\(" clojure--keyword-sym-regexp "\\)")
        (1 'clojure-keyword-face)
        (2 font-lock-type-face)
        ;; (2 'clojure-keyword-face)
        (3 'default)
        (4 'clojure-keyword-face))
-      (,(concat "\\(:\\{1,2\\}\\)\\(" clojure--sym-regexp "\\)")
+      (,(concat "\\(:\\{1,2\\}\\)\\(" clojure--keyword-sym-regexp "\\)")
        (1 'clojure-keyword-face)
        (2 'clojure-keyword-face))
 

--- a/test.clj
+++ b/test.clj
@@ -163,6 +163,11 @@
   {:oneword/ve/yCom|pLex.stu-ff 0}
   {:oneword/.ve/yCom|pLex.stu-ff 0}
 
+  :1oneword
+  :ns/1word
+  :1ns/word
+  :1ns/1word
+
   {:seg.mnt 0}
   ;; {:@seg.mnt 0} ; not allowed
   {:#seg.mnt 0}

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -487,10 +487,16 @@ DESCRIPTION is the description of the spec."
 
   (when-fontifying-it "should handle oneword keywords"
     (" :oneword"
-     (3 9 clojure-keyword-face ))
+     (3 9 clojure-keyword-face))
+
+    (" :1oneword"
+     (3 10 clojure-keyword-face))
 
     ("{:oneword 0}"
      (3 9 clojure-keyword-face))
+
+    ("{:1oneword 0}"
+     (3 10 clojure-keyword-face))
 
     ("{:#oneword 0}"
      (3 10 clojure-keyword-face))
@@ -563,7 +569,22 @@ DESCRIPTION is the description of the spec."
      (10 17 clojure-keyword-face))
 
     (":_:_:foo/bar_:_:foo"
-     (10 19 clojure-keyword-face)))
+     (10 19 clojure-keyword-face))
+
+    (":1foo/bar"
+     (2 5 font-lock-type-face)
+     (6 6 default)
+     (7 9 clojure-keyword-face))
+
+    (":foo/1bar"
+     (2 4 font-lock-type-face)
+     (5 5 default)
+     (6 9 clojure-keyword-face))
+
+    (":1foo/1bar"
+     (2 5 font-lock-type-face)
+     (6 6 default)
+     (7 10 clojure-keyword-face)))
 
   (when-fontifying-it "should handle segment keywords"
     (" :seg.mnt"


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/clojure-mode/issues/581

[Context](https://github.com/clojure-emacs/clojure-mode/issues/581#issuecomment-1204844737)

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
