### PR TITLE
Set add-log-current-defun-function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#629](https://github.com/clojure-emacs/clojure-mode/pull/629): Set `add-log-current-defun-function` to new function `clojure-current-defun-name` (this is used by which-function-mode and easy-kill).
+
 ## 5.15.1 (2022-07-30)
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -525,33 +525,35 @@ replacement for `cljr-expand-let`."
     (advice-add 'paredit-convolute-sexp :after #'clojure--replace-let-bindings-and-indent)))
 
 (defun clojure-current-defun-name ()
-    "Return the name of the defun at point, or nil."
-    (save-excursion
-      (let ((location (point)))
-        ;; If we are now precisely at the beginning of a defun, make sure
-        ;; beginning-of-defun finds that one rather than the previous one.
-        (or (eobp) (forward-char 1))
-        (beginning-of-defun)
-        ;; Make sure we are really inside the defun found, not after it.
-        (when (and (looking-at "\\s(")
-		   (progn (end-of-defun)
-			  (< location (point)))
-		   (progn (forward-sexp -1)
-			  (>= location (point))))
-	  (if (looking-at "\\s(")
-	      (forward-char 1))
-	  ;; Skip the defining construct name, e.g. "defn" or "def".
-	  (forward-sexp 1)
-	  ;; The second element is usually a symbol being defined.  If it
-	  ;; is not, use the first symbol in it.
-	  (skip-chars-forward " \t\n'(")
-          ;; Skip metadata
-          (while (looking-at "\\^")
-            (forward-sexp 1)
-            (skip-chars-forward " \t\n'("))
-	  (buffer-substring-no-properties (point)
-					  (progn (forward-sexp 1)
-					         (point)))))))
+  "Return the name of the defun at point, or nil.
+
+`add-log-current-defun-function' is set to this, for use by `which-func'."
+  (save-excursion
+    (let ((location (point)))
+      ;; If we are now precisely at the beginning of a defun, make sure
+      ;; beginning-of-defun finds that one rather than the previous one.
+      (or (eobp) (forward-char 1))
+      (beginning-of-defun)
+      ;; Make sure we are really inside the defun found, not after it.
+      (when (and (looking-at "\\s(")
+		 (progn (end-of-defun)
+			(< location (point)))
+		 (progn (forward-sexp -1)
+			(>= location (point))))
+	(if (looking-at "\\s(")
+	    (forward-char 1))
+	;; Skip the defining construct name, e.g. "defn" or "def".
+	(forward-sexp 1)
+	;; The second element is usually a symbol being defined.  If it
+	;; is not, use the first symbol in it.
+	(skip-chars-forward " \t\n'(")
+        ;; Skip metadata
+        (while (looking-at "\\^")
+          (forward-sexp 1)
+          (skip-chars-forward " \t\n'("))
+	(buffer-substring-no-properties (point)
+					(progn (forward-sexp 1)
+					       (point)))))))
 
 (defun clojure-mode-variables ()
   "Set up initial buffer-local variables for Clojure mode."

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -524,6 +524,35 @@ replacement for `cljr-expand-let`."
                  #'clojure-space-for-delimiter-p)
     (advice-add 'paredit-convolute-sexp :after #'clojure--replace-let-bindings-and-indent)))
 
+(defun clojure-current-defun-name ()
+    "Return the name of the defun at point, or nil."
+    (save-excursion
+      (let ((location (point)))
+        ;; If we are now precisely at the beginning of a defun, make sure
+        ;; beginning-of-defun finds that one rather than the previous one.
+        (or (eobp) (forward-char 1))
+        (beginning-of-defun)
+        ;; Make sure we are really inside the defun found, not after it.
+        (when (and (looking-at "\\s(")
+		   (progn (end-of-defun)
+			  (< location (point)))
+		   (progn (forward-sexp -1)
+			  (>= location (point))))
+	  (if (looking-at "\\s(")
+	      (forward-char 1))
+	  ;; Skip the defining construct name, e.g. "defn" or "def".
+	  (forward-sexp 1)
+	  ;; The second element is usually a symbol being defined.  If it
+	  ;; is not, use the first symbol in it.
+	  (skip-chars-forward " \t\n'(")
+          ;; Skip metadata
+          (while (looking-at "\\^")
+            (forward-sexp 1)
+            (skip-chars-forward " \t\n'("))
+	  (buffer-substring-no-properties (point)
+					  (progn (forward-sexp 1)
+					         (point)))))))
+
 (defun clojure-mode-variables ()
   "Set up initial buffer-local variables for Clojure mode."
   (add-to-list 'imenu-generic-expression '(nil clojure-match-next-def 0))
@@ -552,6 +581,7 @@ replacement for `cljr-expand-let`."
   (setq-local parse-sexp-ignore-comments t)
   (setq-local prettify-symbols-alist clojure--prettify-symbols-alist)
   (setq-local open-paren-in-column-0-is-defun-start nil)
+  (setq-local add-log-current-defun-function #'clojure-current-defun-name)
   (setq-local beginning-of-defun-function #'clojure-beginning-of-defun-function))
 
 (defsubst clojure-in-docstring-p ()


### PR DESCRIPTION
A number of emacs' programming modes[1] set the variable `add-log-current-defun-function` to a function which returns the current defun/function/variable/etc name, e.g. in `lisp/emacs-lisp/lisp-mode.el`: `(setq-local add-log-current-defun-function #'lisp-current-defun-name)` (https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/emacs-lisp/lisp-mode.el#n683).

This variable is used by which-function-mode to get the name of the current function (otherwise it falls back to some logic based on imenu). It is also used by easy-kill, which then allows the copying of the current defun name (`M-w D`). The latter is the reason I wanted this, as it doesn't work without setting the variable. I haven't discovered anything else that uses it.

The function I have added (`clojure-current-defun-name`) is a copy of lisp-current-defun-name from `lisp-mode.el` (https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/emacs-lisp/lisp-mode.el#n730), with the small addition of the code to skip metadata (indicated the "Skip metadata" comment), and a tweak to the comments.

I have been using this for a few weeks without issue. It works with def, defn, defn-, defmacro and ns fine.

The convention seems to be to call the function `foo-current-defun-name`, even when the language doesn't use `defun` (e.g. `perl-current-defun-name`, `sh-current-defun-name`, `html-current-defun-name`), so I have stuck with that.

[1] A quick search in `lisp/` in the emacs source turned up these: autoconf, idlwave, cfengine, fortran, cperl-mode, scheme, m4-mode, make-mode, perl-mode, sh-script, tcl, cc-mode, python, octave, ruby-mode, f90, texinfo, sgml-mode, css-mode, tex-mode, diff-mode, org-mode.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
