### PR TITLE
Fix second element of forms starting with 'def' being highlighted as function name

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -878,10 +878,9 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
                 "\\(?:#?^\\(?:{[^}]*}\\|\\sw+\\)[ \r\n\t]*\\)*"
                 "\\(\\sw+\\)?")
        (2 font-lock-type-face nil t))
-      ;; Function definition (anything that starts with def and is not
-      ;; listed above)
-      (,(concat "(\\(?:" clojure--sym-regexp "/\\)?"
-                "\\(def[^ \r\n\t]*\\)"
+      ;; Function definition
+      (,(concat "(\\(?:clojure.core/\\)?"
+                "\\(defn\\)"
                 ;; Function declarations
                 "\\>"
                 ;; Any whitespace

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -776,17 +776,17 @@ DESCRIPTION is the description of the spec."
      (6 42 clojure-keyword-face)))
 
   (when-fontifying-it "should handle namespaced defs"
-    ("(_c4/defn bar [] nil)"
-     (2 4 font-lock-type-face)
-     (5 5 nil)
-     (6 9 font-lock-keyword-face)
-     (11 13 font-lock-function-name-face))
+    ("(clojure.core/defn bar [] nil)"
+     (2 13 font-lock-type-face)
+     (14 14 nil)
+     (15 18 font-lock-keyword-face)
+     (20 22 font-lock-function-name-face))
 
-    ("(clo/defrecord foo nil)"
-     (2 4 font-lock-type-face)
-     (5 5 nil)
-     (6 14 font-lock-keyword-face)
-     (16 18 font-lock-function-name-face))
+    ("(clojure.core/defrecord foo nil)"
+     (2 13 font-lock-type-face)
+     (14 14 nil)
+     (15 23 font-lock-keyword-face)
+     (25 27 font-lock-type-face))
 
     ("(s/def ::keyword)"
      (2 2 font-lock-type-face)


### PR DESCRIPTION
Follow up to https://github.com/clojure-emacs/clojure-mode/pull/630

Forgot to make function definition regexp only look for `defn` forms. This PR will fix such behaviour:
![image](https://user-images.githubusercontent.com/47952597/188257884-7508a400-8d38-49f7-8421-1d6a8a9c1518.png)

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
