### PR TITLE
Fix imenu with Clojure code in string or comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#581](https://github.com/clojure-emacs/clojure-mode/issues/581): Fix font locking not working for keywords starting with a number.
 * [#377](https://github.com/clojure-emacs/clojure-mode/issues/377): Fix everything starting with the prefix 'def' being highlighted as a definition form. Now definition forms are enumerated explicitly in the font-locking code, like all other forms.
+* [#638](https://github.com/clojure-emacs/clojure-mode/pull/638): Fix imenu with Clojure code in string or comment.
 
 ## 5.15.1 (2022-07-30)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -777,7 +777,9 @@ Called by `imenu--generic-function'."
       (let (found?
             (deftype (match-string 2))
             (start (point)))
-        (down-list)
+        ;; ignore user-error from down-list when called from inside a string or comment
+        (ignore-errors
+          (down-list))
         (forward-sexp)
         (while (not found?)
           (ignore-errors


### PR DESCRIPTION
Ignore error that's thrown from `down-list` when called
with point inside a string or comment.

E.g. with code like:

```
(defn foo []
  (let [a "
(defn b [_]
  (bar {:bla \"bla\"}))"]))
```

`clojure-match-next-def` calls `down-list` with point inside
the string and `down-list` will throw an user-error with
"This command doesn't work in strings or comments".

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md