### PR TITLE
`clojure-find-ns`: never raise errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* `clojure-find-ns`: never raise errors, returning nil instead on unparseable ns forms.
+* `clojure-find-ns`: add an option to never raise errors, returning nil instead on unparseable ns forms.
 
 ## 5.16.1 (2023-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* `clojure-find-ns`: never raise errors, returning nil instead on unparseable ns forms.
+
 ## 5.16.1 (2023-06-26)
 
 ### Changes

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2142,19 +2142,19 @@ DIRECTION is `forward' or `backward'."
               (setq candidate (string-remove-prefix "'" (thing-at-point 'symbol))))))))
     candidate))
 
-(defun clojure-find-ns (&optional favor-nil)
-  "Return the namespace of the current Clojure buffer, honor `FAVOR-NIL'.
+(defun clojure-find-ns (&optional suppress-errors)
+  "Return the namespace of the current Clojure buffer, honor `SUPPRESS-ERRORS'.
 Return the namespace closest to point and above it.  If there are
 no namespaces above point, return the first one in the buffer.
 
-If `FAVOR-NIL' is t, errors during ns form parsing will be swallowed,
+If `SUPPRESS-ERRORS' is t, errors during ns form parsing will be swallowed,
 and nil will be returned instead of letting this function fail.
 
 The results will be cached if `clojure-cache-ns' is set to t."
   (if (and clojure-cache-ns clojure-cached-ns)
       clojure-cached-ns
     (let* ((f (lambda (direction)
-                (if favor-nil
+                (if suppress-errors
                     (ignore-errors (clojure--find-ns-in-direction direction))
                   (clojure--find-ns-in-direction direction))))
            (ns (save-excursion

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2127,20 +2127,21 @@ the cached value will be updated automatically."
 (defun clojure--find-ns-in-direction (direction)
   "Return the nearest namespace in a specific DIRECTION.
 DIRECTION is `forward' or `backward'."
-  (let ((candidate)
-        (fn (if (eq direction 'forward)
-                #'search-forward-regexp
-              #'search-backward-regexp)))
-    (while (and (not candidate)
-                (funcall fn clojure-namespace-regexp nil t))
-      (let ((end (match-end 0)))
-        (save-excursion
-          (save-match-data
-            (goto-char end)
-            (clojure-forward-logical-sexp)
-            (unless (or (clojure--in-string-p) (clojure--in-comment-p))
-              (setq candidate (string-remove-prefix "'" (thing-at-point 'symbol))))))))
-    candidate))
+  (ignore-errors
+    (let ((candidate)
+          (fn (if (eq direction 'forward)
+                  #'search-forward-regexp
+                #'search-backward-regexp)))
+      (while (and (not candidate)
+                  (funcall fn clojure-namespace-regexp nil t))
+        (let ((end (match-end 0)))
+          (save-excursion
+            (save-match-data
+              (goto-char end)
+              (clojure-forward-logical-sexp)
+              (unless (or (clojure--in-string-p) (clojure--in-comment-p))
+                (setq candidate (string-remove-prefix "'" (thing-at-point 'symbol))))))))
+      candidate)))
 
 (defun clojure-find-ns ()
   "Return the namespace of the current Clojure buffer.

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2127,39 +2127,45 @@ the cached value will be updated automatically."
 (defun clojure--find-ns-in-direction (direction)
   "Return the nearest namespace in a specific DIRECTION.
 DIRECTION is `forward' or `backward'."
-  (ignore-errors
-    (let ((candidate)
-          (fn (if (eq direction 'forward)
-                  #'search-forward-regexp
-                #'search-backward-regexp)))
-      (while (and (not candidate)
-                  (funcall fn clojure-namespace-regexp nil t))
-        (let ((end (match-end 0)))
-          (save-excursion
-            (save-match-data
-              (goto-char end)
-              (clojure-forward-logical-sexp)
-              (unless (or (clojure--in-string-p) (clojure--in-comment-p))
-                (setq candidate (string-remove-prefix "'" (thing-at-point 'symbol))))))))
-      candidate)))
+  (let ((candidate)
+        (fn (if (eq direction 'forward)
+                #'search-forward-regexp
+              #'search-backward-regexp)))
+    (while (and (not candidate)
+                (funcall fn clojure-namespace-regexp nil t))
+      (let ((end (match-end 0)))
+        (save-excursion
+          (save-match-data
+            (goto-char end)
+            (clojure-forward-logical-sexp)
+            (unless (or (clojure--in-string-p) (clojure--in-comment-p))
+              (setq candidate (string-remove-prefix "'" (thing-at-point 'symbol))))))))
+    candidate))
 
-(defun clojure-find-ns ()
-  "Return the namespace of the current Clojure buffer.
+(defun clojure-find-ns (&optional favor-nil)
+  "Return the namespace of the current Clojure buffer, honor `FAVOR-NIL'.
 Return the namespace closest to point and above it.  If there are
 no namespaces above point, return the first one in the buffer.
+
+If `FAVOR-NIL' is t, errors during ns form parsing will be swallowed,
+and nil will be returned instead of letting this function fail.
 
 The results will be cached if `clojure-cache-ns' is set to t."
   (if (and clojure-cache-ns clojure-cached-ns)
       clojure-cached-ns
-    (let ((ns (save-excursion
-                (save-restriction
-                  (widen)
+    (let* ((f (lambda (direction)
+                (if favor-nil
+                    (ignore-errors (clojure--find-ns-in-direction direction))
+                  (clojure--find-ns-in-direction direction))))
+           (ns (save-excursion
+                 (save-restriction
+                   (widen)
 
-                  ;; Move to top-level to avoid searching from inside ns
-                  (ignore-errors (while t (up-list nil t t)))
+                   ;; Move to top-level to avoid searching from inside ns
+                   (ignore-errors (while t (up-list nil t t)))
 
-                  (or (clojure--find-ns-in-direction 'backward)
-                      (clojure--find-ns-in-direction 'forward))))))
+                   (or (funcall f 'backward)
+                       (funcall f 'forward))))))
       (setq clojure-cached-ns ns)
       ns)))
 

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -167,7 +167,13 @@
             (expect (clojure-find-ns) :to-equal expected)
             ;; After both namespaces
             (goto-char (point-max))
-            (expect (clojure-find-ns) :to-equal expected)))))))
+            (expect (clojure-find-ns) :to-equal expected))))))
+
+  (it "should return nil for an invalid ns form"
+      ;; we should not cache the results of `clojure-find-ns' here
+      (let ((clojure-cache-ns nil))
+        (with-clojure-buffer "(ns )"
+          (expect (equal nil (clojure-find-ns)))))))
 
 (describe "clojure-sexp-starts-until-position"
   (it "should return starting points for forms after POINT until POSITION"

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -169,7 +169,7 @@
             (goto-char (point-max))
             (expect (clojure-find-ns) :to-equal expected))))))
 
-  (describe "`favor-nil' argument"
+  (describe "`suppress-errors' argument"
     (let ((clojure-cache-ns nil))
       (describe "given a faulty ns form"
         (let ((ns-form "(ns )"))

--- a/test/clojure-mode-sexp-test.el
+++ b/test/clojure-mode-sexp-test.el
@@ -169,11 +169,20 @@
             (goto-char (point-max))
             (expect (clojure-find-ns) :to-equal expected))))))
 
-  (it "should return nil for an invalid ns form"
-      ;; we should not cache the results of `clojure-find-ns' here
-      (let ((clojure-cache-ns nil))
-        (with-clojure-buffer "(ns )"
-          (expect (equal nil (clojure-find-ns)))))))
+  (describe "`favor-nil' argument"
+    (let ((clojure-cache-ns nil))
+      (describe "given a faulty ns form"
+        (let ((ns-form "(ns )"))
+          (describe "when the argument is `t'"
+            (it "causes `clojure-find-ns' to return nil"
+              (with-clojure-buffer ns-form
+                                   (expect (equal nil (clojure-find-ns t))))))
+
+          (describe "when the argument is `nil'"
+            (it "causes `clojure-find-ns' to return raise an error"
+              (with-clojure-buffer ns-form
+                                   (expect (clojure-find-ns nil)
+                                           :to-throw 'error)))))))))
 
 (describe "clojure-sexp-starts-until-position"
   (it "should return starting points for forms after POINT until POSITION"


### PR DESCRIPTION
See also https://github.com/clojure-emacs/cider/issues/2849 for a use case and discussion.

One can see quite a few usages of `clojure-find-ns` in CIDER. Those assume a possible nil value, e.g.:

https://github.com/clojure-emacs/cider/blob/0e76b141054f091fa1a21fea7f2a5604b2f7f8d4/cider-client.el#L129-L130

...so the proposed change would be aligned with the existing usage.

Cheers - V