### PR TITLE
Fix clojure-find-ns 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#593](https://github.com/clojure-emacs/clojure-mode/issues/593): Fix clojure-find-ns when ns form is preceded by whitespace or inside comment form.
+
 ## 5.16.2 (2023-08-23)
 
 ### Changes

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2125,7 +2125,7 @@ content) are considered part of the preceding sexp."
 (make-obsolete-variable 'clojure-namespace-name-regex 'clojure-namespace-regexp "5.12.0")
 
 (defconst clojure-namespace-regexp
-  (rx line-start "(" (? "clojure.core/") (or "in-ns" "ns" "ns+") symbol-end))
+  (rx line-start (zero-or-more whitespace) "(" (? "clojure.core/") (or "in-ns" "ns" "ns+") symbol-end))
 
 (defcustom clojure-cache-ns nil
   "Whether to cache the results of `clojure-find-ns'.
@@ -2153,7 +2153,7 @@ DIRECTION is `forward' or `backward'."
           (save-match-data
             (goto-char end)
             (clojure-forward-logical-sexp)
-            (unless (or (clojure--in-string-p) (clojure--in-comment-p))
+            (unless (or (clojure--in-string-p) (clojure--in-comment-p) (clojure-top-level-form-p "comment"))
               (setq candidate (string-remove-prefix "'" (thing-at-point 'symbol))))))))
     candidate))
 
@@ -2275,6 +2275,8 @@ This will skip over sexps that don't represent objects, so that ^hints and
   (condition-case nil
       (save-excursion
         (beginning-of-defun)
+        (clojure-forward-logical-sexp 1)
+        (clojure-backward-logical-sexp 1)
         (forward-char 1)
         (clojure-forward-logical-sexp 1)
         (clojure-backward-logical-sexp 1)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2275,11 +2275,7 @@ This will skip over sexps that don't represent objects, so that ^hints and
   (condition-case nil
       (save-excursion
         (beginning-of-defun-raw)
-        ;; Go to beginning of sexp
-        (clojure-forward-logical-sexp 1)
-        (clojure-backward-logical-sexp 1)
         (forward-char 1)
-        ;; Go to beginning of operator
         (clojure-forward-logical-sexp 1)
         (clojure-backward-logical-sexp 1)
         (looking-at-p first-form))

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2275,9 +2275,11 @@ This will skip over sexps that don't represent objects, so that ^hints and
   (condition-case nil
       (save-excursion
         (beginning-of-defun)
+        ;; Go to beginning of sexp
         (clojure-forward-logical-sexp 1)
         (clojure-backward-logical-sexp 1)
         (forward-char 1)
+        ;; Go to beginning of operator
         (clojure-forward-logical-sexp 1)
         (clojure-backward-logical-sexp 1)
         (looking-at-p first-form))

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -86,6 +86,9 @@
     (with-clojure-buffer "  (ns foo)"
       (expect (clojure-find-ns) :to-equal "foo")))
   (it "should skip namespaces within any comment forms"
+    (with-clojure-buffer "(comment
+      (ns foo))"
+      (expect (clojure-find-ns) :to-equal nil))
     (with-clojure-buffer " (ns foo)
      (comment
       (ns bar))"
@@ -95,8 +98,7 @@
      (ns bar)
     (comment
       (ns baz))"
-      (expect (clojure-find-ns) :to-equal "bar"))
-    )
+      (expect (clojure-find-ns) :to-equal "bar")))
   (it "should find namespace declarations with nested metadata and docstrings"
     (with-clojure-buffer "(ns ^{:bar true} foo)"
       (expect (clojure-find-ns) :to-equal "foo"))

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -82,6 +82,21 @@
       (expect (clojure-find-ns) :to-equal "foo"))
     (with-clojure-buffer "(ns ^:bar ^:baz foo)"
       (expect (clojure-find-ns) :to-equal "foo")))
+  (it "should find namespaces with spaces before ns form"
+    (with-clojure-buffer "  (ns foo)"
+      (expect (clojure-find-ns) :to-equal "foo")))
+  (it "should skip namespaces within any comment forms"
+    (with-clojure-buffer " (ns foo)
+     (comment
+      (ns bar))"
+      (expect (clojure-find-ns) :to-equal "foo"))
+    (with-clojure-buffer " (comment
+      (ns foo))
+     (ns bar)
+    (comment
+      (ns baz))"
+      (expect (clojure-find-ns) :to-equal "bar"))
+    )
   (it "should find namespace declarations with nested metadata and docstrings"
     (with-clojure-buffer "(ns ^{:bar true} foo)"
       (expect (clojure-find-ns) :to-equal "foo"))


### PR DESCRIPTION
- when ns is preceded by whitespace or inside comment form.
- closes https://github.com/clojure-emacs/clojure-mode/issues/593

