### PR TITLE
Declare indentation for the `async` ClojureScript macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Declare indentation for the `async` ClojureScript macro. 
+
 ## 5.17.0 (2023-09-11)
 
 ### Changes

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1876,6 +1876,7 @@ work).  To set it from Lisp code, use
   (deftest :defn)
   (are 2)
   (use-fixtures :defn)
+  (async 1)
 
   ;; core.logic
   (run :defn)


### PR DESCRIPTION
https://github.com/clojure/clojurescript/blob/067eaef03678a06d83caf3f66ddf20f9ee71db5b/src/main/cljs/cljs/test.cljc#L248-L260