### PR TITLE
Don't highlight vars with colons as keywords

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1072,12 +1072,13 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
       ;; keywords: {:oneword/ve/yCom|pLex.stu-ff 0}
       (,(concat "\\(:\\{1,2\\}\\)\\(" clojure--keyword-sym-regexp "?\\)\\(/\\)"
                 "\\(" clojure--keyword-sym-regexp "\\)")
+       ;; with ns
        (1 'clojure-keyword-face)
        (2 font-lock-type-face)
-       ;; (2 'clojure-keyword-face)
        (3 'default)
        (4 'clojure-keyword-face))
-      (,(concat "\\(:\\{1,2\\}\\)\\(" clojure--keyword-sym-regexp "\\)")
+      (,(concat "\\<\\(:\\{1,2\\}\\)\\(" clojure--keyword-sym-regexp "\\)")
+       ;; without ns
        (1 'clojure-keyword-face)
        (2 'clojure-keyword-face))
 

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -265,6 +265,10 @@ DESCRIPTION is the description of the spec."
     ("(colons:are:okay)"
      (2 16 nil))
 
+    ("(some-ns/colons:are:okay)"
+     (2 8 font-lock-type-face)
+     (9 24 nil))
+
     ("(oneword/ve/yCom|pLex.stu-ff)"
      (2 8 font-lock-type-face)
      (9 10 nil)

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -722,6 +722,19 @@ DESCRIPTION is the description of the spec."
      (10 10 default)
      (11 30 clojure-keyword-face)))
 
+  (when-fontifying-it "should handle keywords with colons"
+    (":a:a"
+     (1 4 clojure-keyword-face))
+
+    (":a:a/:a"
+     (1 7 clojure-keyword-face))
+
+    ("::a:a"
+     (1 5 clojure-keyword-face))
+
+    ("::a.a:a"
+     (1 7 clojure-keyword-face)))
+
   (when-fontifying-it "should handle very complex keywords"
     (" :ve/yCom|pLex.stu-ff"
      (3 4 font-lock-type-face)

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -262,6 +262,9 @@ DESCRIPTION is the description of the spec."
      (9 10 nil)
      (11 16 nil))
 
+    ("(colons:are:okay)"
+     (2 16 nil))
+
     ("(oneword/ve/yCom|pLex.stu-ff)"
      (2 8 font-lock-type-face)
      (9 10 nil)
@@ -824,7 +827,10 @@ DESCRIPTION is the description of the spec."
   (when-fontifying-it "should handle variables defined with def"
     ("(def foo 10)"
      (2 4 font-lock-keyword-face)
-     (6 8 font-lock-variable-name-face)))
+     (6 8 font-lock-variable-name-face))
+    ("(def foo:bar 10)"
+     (2 4 font-lock-keyword-face)
+     (6 12 font-lock-variable-name-face)))
 
   (when-fontifying-it "should handle variables definitions of type string"
     ("(def foo \"hello\")"


### PR DESCRIPTION
Fixes #653

Changes syntax highlighting regexp for keywords to match a colon/double-colon only at the beginning of a word, not in the middle. This allows local vars like `foo:bar` to be highlighted correctly instead of like an unknown symbol for the part before the colon and a keyword for the rest.

For my own reference, the "\\<" is per https://www.gnu.org/savannah-checkouts/gnu/emacs/manual/html_node/emacs/Regexp-Backslash.html#Regexp-Backslash

### Test suite
```clojure
(def foo:bar 5)
(def legal*stuff 10)
(def very*****legal 10)

;; wrong
f:bar
foo:bar
defined-in-another-ns/bar:baz
foooooo:bar

;; right
(try)
fubar
inc
legal*stuff
very*****legal
defined-in-another-ns/lorem-ipsum
:baz
::qualified
(:baz {:baz 5})
:qux/foo
::ns/name
*ns*
*assert*
clojure.core/*assert*
(*assert*)
nil
```


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [ ] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
