### PR TITLE
Fix multi-digit lambda args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#671](https://github.com/clojure-emacs/clojure-mode/issues/671): Syntax highlighting for digits after the first in % args
+
 ## 5.18.1 (2023-11-24)
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1058,7 +1058,7 @@ any number of matches of `clojure--sym-forbidden-rest-chars'."))
        1 'clojure-character-face)
       ;; lambda arguments - %, %&, %1, %2, etc
       ;; must come after character literals for \% to be handled properly
-      ("\\<%[&1-9]?" (0 font-lock-variable-name-face))
+      ("\\<%[&1-9]*" (0 font-lock-variable-name-face))
       ;; namespace definitions: (ns foo.bar)
       (,(concat "(\\<ns\\>[ \r\n\t]*"
                 ;; Possibly metadata, shorthand and/or longhand

--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -901,12 +901,23 @@ DESCRIPTION is the description of the spec."
      (2 3 font-lock-keyword-face)
      ( 5 7 font-lock-function-name-face)))
 
-  (when-fontifying-it "should handle lambda-params"
+  (when-fontifying-it "should handle lambda-params %, %1, %n..."
     ("#(+ % %2 %3 %&)"
      (5 5 font-lock-variable-name-face)
      (7 8 font-lock-variable-name-face)
      (10 11 font-lock-variable-name-face)
      (13 14 font-lock-variable-name-face)))
+
+  (when-fontifying-it "should handle multi-digit lambda-params"
+    ;; % args with >1 digit are rare and unidiomatic but legal up to
+    ;; `MAX_POSITIONAL_ARITY` in Clojure's compiler, which as of today is 20
+    ("#(* %10 %15 %19 %20)"
+     ;; it would be better if this were just `font-lock-variable-name-face` but
+     ;; it seems to work as-is
+     (5 7   various-faces)
+     (9 11  font-lock-variable-name-face)
+     (13 15 font-lock-variable-name-face)
+     (17 19 various-faces)))
 
   (when-fontifying-it "should handle nils"
     ("(= nil x)"


### PR DESCRIPTION
Fixes #671 by syntax-highlighting multi-digit lambda arguments, e.g. `#(+ %10 %19)`. 

Does not attempt to distinguish between %20 (which is both reader-legal and works) and %21 (which is reader-legal but does not compile) because that's complex and depends on Clojure compiler internals.


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [x] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
