### PR TITLE
Fix "wrong-type-argument integerp" error in `clojure-align` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bugs fixed
 
+* Fix `clojure-align` when called from `clojure-ts-mode` major mode buffers
+
+### Bugs fixed
+
 * [#671](https://github.com/clojure-emacs/clojure-mode/issues/671): Syntax highlighting for digits after the first in % args
 
 ## 5.18.1 (2023-11-24)

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -1469,7 +1469,7 @@ When called from lisp code align everything between BEG and END."
             (cl-incf count)))
         ;; Pre-indent the region to avoid aligning to improperly indented
         ;; contents (#551). Also fixes #360.
-        (indent-region (point) sexp-end)
+        (indent-region (point) (marker-position sexp-end))
         (dotimes (_ count)
           (align-region (point) sexp-end nil
                         `((clojure-align (regexp . clojure--search-whitespace-after-next-sexp)


### PR DESCRIPTION
Background: `clojure-ts-mode` doesn't (yet) have an equivalent to `clojure-align` for vertically aligning contents of sexps. See https://github.com/clojure-emacs/clojure-ts-mode/issues/16

To aid this for the time being, users of `clojure-ts-mode` major mode could use `clojure-mode`'s `clojure-align`.

However, this currently fails with this error (tested on `Emacs 29.2`):

```
Debugger entered--Lisp error: (wrong-type-argument integerp #<marker at 16 in *scratch-clj*>)
  treesit-query-range(clojure #<treesit-compiled-query> 3 #<marker at 16 in *scratch-clj*>)
  treesit-update-ranges(3 #<marker at 16 in *scratch-clj*>)
  treesit-indent-region(3 #<marker at 16 in *scratch-clj*>)
  indent-region(3 #<marker at 16 in *scratch-clj*>)
  (let ((sexp-end (save-excursion (backward-up-list) (forward-sexp 1) (point-marker))) (clojure-align-forms-automatically nil) (count 1)) (save-excursion (while (search-forward-regexp "^ *\n" sexp-end 'noerror) (setq count (1+ count)))) (indent-region (point) sexp-end) (let ((upper-bound count) (counter 0)) (while (< counter upper-bound) (let ((_ counter)) (align-region (point) sexp-end nil (list (cons 'clojure-align (cons ... ...))) nil)) (setq counter (1+ counter)))))
  (while (clojure--find-sexp-to-align end) (let ((sexp-end (save-excursion (backward-up-list) (forward-sexp 1) (point-marker))) (clojure-align-forms-automatically nil) (count 1)) (save-excursion (while (search-forward-regexp "^ *\n" sexp-end 'noerror) (setq count (1+ count)))) (indent-region (point) sexp-end) (let ((upper-bound count) (counter 0)) (while (< counter upper-bound) (let ((_ counter)) (align-region (point) sexp-end nil (list (cons ... ...)) nil)) (setq counter (1+ counter))))))
  (save-excursion (goto-char beg) (while (clojure--find-sexp-to-align end) (let ((sexp-end (save-excursion (backward-up-list) (forward-sexp 1) (point-marker))) (clojure-align-forms-automatically nil) (count 1)) (save-excursion (while (search-forward-regexp "^ *\n" sexp-end 'noerror) (setq count (1+ count)))) (indent-region (point) sexp-end) (let ((upper-bound count) (counter 0)) (while (< counter upper-bound) (let ((_ counter)) (align-region (point) sexp-end nil (list ...) nil)) (setq counter (1+ counter)))))))
  clojure-align(2 17)
  funcall-interactively(clojure-align 2 17)
  command-execute(clojure-align record)
  counsel-M-x-action("clojure-align")
  #f(compiled-function (x) #<bytecode -0x184d662e7783db00>)("clojure-align")
 ...
```

It seems `treesit-indent-region`  is picky to actually get the positions as integers, whereas other implementations also accept markers.

This change ensures that `indent-region` is called with the positions as integers, allowing `clojure-align` also being successfully called from `clojure-ts-mode` buffers.

Tests: As there is no test harness yet for `clojure-ts-mode`, I think there is only to ensure `clojure-align` still works as expected from `clojure-mode` major mode, which [is covered here](https://github.com/clojure-emacs/clojure-mode/blob/222fdafa2add56a171ded245339a383e5e3078ec/test/clojure-mode-indentation-test.el#L812-L836).
