### PR TITLE
Fix windows CI build by allowing to run emacs.portable's scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run:
           name: Install Emacs latest
           command: |
-            choco install emacs
+            choco install emacs -y
       - setup-windows
       - test
       - lint


### PR DESCRIPTION
Trying to address build failure from https://app.circleci.com/pipelines/github/clojure-emacs/clojure-mode/403/workflows/e0d20e51-eca4-4997-beca-16519ed48856/jobs/1525

```
#!powershell.exe -ExecutionPolicy Bypass
choco install emacs

Chocolatey v2.2.2
Installing the following packages:
emacs
By installing, you accept licenses for the packages.
Progress: Downloading emacs.portable 28.2.0... 100%

emacs.portable v28.2.0 [Approved]
emacs.portable package files install completed. Performing other installation steps.
The package emacs.portable wants to run 'chocolateyInstall.ps1'.
Note: If you don't run this script, the installation will fail.
Note: To confirm automatically next time, use '-y' or consider:
choco feature enable -n allowGlobalConfirmation
Do you want to run the script?([Y]es/[A]ll - yes to all/[N]o/[P]rint): 
Timeout or your choice of '' is not a valid selection.
You must select an answer
Do you want to run the script?([Y]es/[A]ll - yes to all/[N]o/[P]rint): 
Timeout or your choice of '' is not a valid selection.
You must select an answer
```