### PR TITLE
Identify `basilisp.edn` and `.lpy` file extensions as Clojure type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * [#671](https://github.com/clojure-emacs/clojure-mode/issues/671): Syntax highlighting for digits after the first in % args
 
+# Changes
+
+* [#675](https://github.com/clojure-emacs/clojure-mode/issues/675): Add `.lpy` to the list of known Clojure file extensions. 
+
 ## 5.18.1 (2023-11-24)
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -236,6 +236,7 @@ For example, \[ is allowed in :db/id[:db.part/user]."
     "shadow-cljs.edn"  ; shadow-cljs
     "bb.edn"           ; babashka
     "nbb.edn"          ; nbb
+    "basilisp.edn"     ; Basilisp (Python)
     )
   "A list of files, which identify a Clojure project's root.
 Out-of-the box `clojure-mode' understands lein, boot, gradle,
@@ -3320,7 +3321,7 @@ With universal argument \\[universal-argument], act on the \"top-level\" form."
 ;;;###autoload
 (progn
   (add-to-list 'auto-mode-alist
-               '("\\.\\(clj\\|cljd\\|dtm\\|edn\\)\\'" . clojure-mode))
+               '("\\.\\(clj\\|cljd\\|dtm\\|edn\\|lpy\\)\\'" . clojure-mode))
   (add-to-list 'auto-mode-alist '("\\.cljc\\'" . clojurec-mode))
   (add-to-list 'auto-mode-alist '("\\.cljs\\'" . clojurescript-mode))
   ;; boot build scripts are Clojure source files


### PR DESCRIPTION
Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [x] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

I haven't added any tests yet because of the simplicity of the change and closely following the `.clj` paradigm, but let me know if this is of concern.

The `basilisp.edn` file is a project placeholder that has no other use at the moment other to provisionally indicate this is the root of a Basilisp project.

I plan to add some syntax highlighting for builtin Basilisp symbol at some later point, at the moment I'm just looking at minimal support to get it working with Cider.

Thanks