### PR TITLE
Set lexical-binding in clojure-mode-font-lock-test.el

### DIFF
--- a/test/clojure-mode-font-lock-test.el
+++ b/test/clojure-mode-font-lock-test.el
@@ -1,5 +1,4 @@
-;;; clojure-mode-font-lock-test.el --- Clojure Mode: Font lock test suite
-;; -*- lexical-binding: t; -*-
+;;; clojure-mode-font-lock-test.el --- Clojure Mode: Font lock test suite -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014-2021 Bozhidar Batsov <bozhidar@batsov.dev>
 


### PR DESCRIPTION
Must have been moved to the second line by a well-meaning fill operation. Unfortunately, it has no effect on the second line and the tests broke on buttercup 1.34.

See https://bugs.gentoo.org/926084 as reported in https://github.com/jorgenschaefer/emacs-buttercup/issues/243
