### PR TITLE
Fix syntax-table class of carriage returns

### DIFF
--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -373,7 +373,8 @@ The prefixes are used to generate the correct namespace."
 (defvar clojure-mode-syntax-table
   (let ((table (make-syntax-table)))
     ;; Initialize ASCII charset as symbol syntax
-    (modify-syntax-entry '(0 . 127) "_" table)
+    ;; Control characters from 0-31 default to the punctuation syntax class
+    (modify-syntax-entry '(32 . 127) "_" table)
 
     ;; Word syntax
     (modify-syntax-entry '(?0 . ?9) "w" table)
@@ -385,6 +386,7 @@ The prefixes are used to generate the correct namespace."
     (modify-syntax-entry ?\xa0 " " table) ; non-breaking space
     (modify-syntax-entry ?\t " " table)
     (modify-syntax-entry ?\f " " table)
+    (modify-syntax-entry ?\r " " table)
     ;; Setting commas as whitespace makes functions like `delete-trailing-whitespace' behave unexpectedly (#561)
     (modify-syntax-entry ?, "." table)
 


### PR DESCRIPTION
The syntax table interprets ASCII control chars (including CRs) as symbols in clojure buffers, affecting functions such as (thing-at-point 'symbol)
This caused clojure-find-ns to report "^M" as the namespace in some files with \r\n line encodings.


-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
