### PR TITLE
Don't use custom logic to find source directory of clojure-mode.el

### DIFF
--- a/test/utils/test-helper.el
+++ b/test/utils/test-helper.el
@@ -25,13 +25,6 @@
 
 (message "Running tests on Emacs %s" emacs-version)
 
-(let* ((current-file (if load-in-progress load-file-name (buffer-file-name)))
-       (source-directory (locate-dominating-file current-file "Eldev"))
-       ;; Do not load outdated byte code for tests
-       (load-prefer-newer t))
-  ;; Load the file under test
-  (load (expand-file-name "clojure-mode" source-directory)))
-
 (defmacro with-clojure-buffer (text &rest body)
   "Create a temporary buffer, insert TEXT, switch to clojure-mode and evaluate BODY."
   (declare (indent 1))


### PR DESCRIPTION
* Or this will prevent buttercup tests from working with installed clojure-mode under ELPA directories.

* A bit more background: in Debian there is autopkgtest which tests the installed package.  dh-elpa enables a mode that runs the same ERT or Buttercup tests against the installed package instead of the source tree.  In this case, it will let the tests pass during build phase, but autopkgtest will fail as this custom code will still try to locate the source code which will no longer be available.

* I have tested under Debian sbuild that removing the code will let the buttercup tests pass under autopkgtest, but not sure whether this is still required for Eldev to work.

-----------------

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [ ] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).
