### PR TITLE
Relax regexp for clojure-find-def to recognize more complex metadata on vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [cider#3758](https://github.com/clojure-emacs/cider/issues/3758): Improve regexp for clojure-find-def to recognize more complex metadata on vars
+
 ## 5.19.0 (2024-05-26)
 
 ### Bugs fixed

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2270,7 +2270,7 @@ renaming a namespace."
           ;; Any whitespace
           "[ \r\n\t]*"
           ;; Possibly type or metadata
-          "\\(?:#?^\\(?:{[^}]*}\\|\\(?:\\sw\\|\\s_\\)+\\)[ \r\n\t]*\\)*"
+          "\\(?:#?^\\(?:{[^}]*}+\\|\\(?:\\sw\\|\\s_\\)+\\)[ \r\n\t]*\\)*"
           ;; Symbol name
           "\\(\\(?:\\sw\\|\\s_\\)+\\)"))
 

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -331,6 +331,38 @@
  {:nested (in|c x)})"
     (clojure-toggle-ignore-defun)))
 
+(describe "clojure-find-def"
+  (it "should recognize def"
+    (with-clojure-buffer-point "(def foo 1)|
+(def bar 2)"
+        (expect (clojure-find-def) :to-equal '("def" "foo"))))
+  (it "should recognize deftest, with or without metadata added to the var"
+    (with-clojure-buffer-point
+        "|(deftest ^{:a 1} simple-metadata)
+         (deftest ^{:a {}} complex-metadata)
+         (deftest no-metadata)"
+        (expect (clojure-find-def) :to-equal '("deftest" "simple-metadata")))
+    (with-clojure-buffer-point
+        "(deftest ^{:a 1} |simple-metadata)
+         (deftest ^{:a {}} complex-metadata)
+         (deftest no-metadata)"
+        (expect (clojure-find-def) :to-equal '("deftest" "simple-metadata")))
+    (with-clojure-buffer-point
+        "(deftest ^{:a 1} simple-metadata)
+         (deftest ^{:a {}} |complex-metadata)
+         (deftest no-metadata)"
+        (expect (clojure-find-def) :to-equal '("deftest" "complex-metadata")))
+    (with-clojure-buffer-point
+        "(deftest ^{:a 1} simple-metadata)
+         (deftest ^{:|a {}} complex-metadata)
+         (deftest no-metadata)"
+        (expect (clojure-find-def) :to-equal '("deftest" "complex-metadata")))
+    (with-clojure-buffer-point
+        "(deftest ^{:a 1} simple-metadata)
+         (deftest ^{:a {}} complex-metadata)
+         (deftest |no-metadata)"
+        (expect (clojure-find-def) :to-equal '("deftest" "no-metadata")))))
+
 (provide 'clojure-mode-util-test)
 
 ;;; clojure-mode-util-test.el ends here

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -332,10 +332,23 @@
     (clojure-toggle-ignore-defun)))
 
 (describe "clojure-find-def"
-  (it "should recognize def"
-    (with-clojure-buffer-point "(def foo 1)|
-(def bar 2)"
-        (expect (clojure-find-def) :to-equal '("def" "foo"))))
+  (it "should recognize def and defn"
+    (with-clojure-buffer-point
+        "(def foo 1)|
+         (defn bar [x y z] z)"
+        (expect (clojure-find-def) :to-equal '("def" "foo")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn bar |[x y z] z)"
+        (expect (clojure-find-def) :to-equal '("defn" "bar")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn ^:private bar |[x y z] z)"
+        (expect (clojure-find-def) :to-equal '("defn" "bar")))
+    (with-clojure-buffer-point
+        "(defn |^{:doc \"A function\"} foo [] 1)
+         (defn ^:private bar 2)"
+        (expect (clojure-find-def) :to-equal '("defn" "foo"))))
   (it "should recognize deftest, with or without metadata added to the var"
     (with-clojure-buffer-point
         "|(deftest ^{:a 1} simple-metadata)


### PR DESCRIPTION
This PR tries to solve an issue that was originally reported on the CIDER project, but was later found to be related to `clojure-mode`: https://github.com/clojure-emacs/cider/issues/3758.

In summary, the problem encountered is that running `cider-test-run-test` on a form like this 
```clj
(deftest ^{:a {}} complex-metadata
  (println "complex-metadata")
  (is true))
```
does not correctly recognize this as a test (in fact it doesn't recognize this as a def-form at all). I traced the underlying issue to the regexp `clojure-def-type-and-name-regex` used by `clojure-find-def`, which I assume make a best-effort attempt at recognizing metadata on vars, but which is not able to match on the form above since it doesn't match metadata maps with more than one right-brace `}`.

The approach in this PR is to modify the regexp to allow for more than one right-brace at the end of the metadata, if it is a map. A more robust approach would be to use an actual Clojure parser, but that might be a bit excessive. 

I didn't find any tests related to `clojure-find-def`, but please let me know if I should add one.

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [ ] The commits are consistent with our [contribution guidelines][1].
- [ ] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
