### PR TITLE
Recognize defn- in `clojure-find-def` for declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [cider#3758](https://github.com/clojure-emacs/cider/issues/3758): Improve regexp for clojure-find-def to recognize more complex metadata on vars
 * [#684](https://github.com/clojure-emacs/clojure-mode/issues/684): Restore `outline-regexp` pattern to permit outline handling of top-level forms.
+* Improve regexp for clojure-find-def to recognize `defn-` and other declarations on the form `def...-`.
 
 ## 5.19.0 (2024-05-26)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -2266,7 +2266,7 @@ renaming a namespace."
 (defconst clojure-def-type-and-name-regex
   (concat "(\\(?:\\(?:\\sw\\|\\s_\\)+/\\)?"
           ;; Declaration
-          "\\(def\\(?:\\sw\\|\\s_\\)*\\)\\>"
+          "\\(def\\(?:\\sw\\|\\s_\\)*\\(?:-\\|\\>\\)\\)"
           ;; Any whitespace
           "[ \r\n\t]*"
           ;; Possibly type or metadata

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -388,7 +388,11 @@
     (with-clojure-buffer-point
         "(defn- |^{:doc \"A function\"} foo [] 1)
          (defn- ^:private bar 2)"
-        (expect (clojure-find-def) :to-equal '("defn-" "foo")))))
+        (expect (clojure-find-def) :to-equal '("defn-" "foo")))
+    (with-clojure-buffer-point
+        "(def-n- |^{:doc \"A function\"} foo [] 1)
+         (defn- ^:private bar 2)"
+        (expect (clojure-find-def) :to-equal '("def-n-" "foo")))))
 
 (provide 'clojure-mode-util-test)
 

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -391,9 +391,38 @@
         (expect (clojure-find-def) :to-equal '("defn-" "foo"))))
   (it "should recognize def...-, with or without metadata"
     (with-clojure-buffer-point
+        "(def foo 1)
+         (def- bar| 5)
+         (def baz 2)"
+        (expect (clojure-find-def) :to-equal '("def-" "bar")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (deftest- bar |[x y z] z)
+         (def baz 2)"
+        (expect (clojure-find-def) :to-equal '("deftest-" "bar")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defxyz- bar| 5)
+         (def baz 2)"
+        (expect (clojure-find-def) :to-equal '("defxyz-" "bar")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn-n- bar| [x y z] z)
+         (def baz 2)"
+        (expect (clojure-find-def) :to-equal '("defn-n-" "bar")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn-n- ^:private bar |[x y z] z)"
+        (expect (clojure-find-def) :to-equal '("defn-n-" "bar")))
+    (with-clojure-buffer-point
         "(def-n- |^{:doc \"A function\"} foo [] 1)
-         (defn- ^:private bar 2)"
-        (expect (clojure-find-def) :to-equal '("def-n-" "foo")))))
+         (def- ^:private bar 2)"
+        (expect (clojure-find-def) :to-equal '("def-n-" "foo")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn-n- ^{:|a {}} complex-metadata |[x y z] z)
+         (def bar 2)"
+        (expect (clojure-find-def) :to-equal '("defn-n-" "complex-metadata")))))
 
 (provide 'clojure-mode-util-test)
 

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -388,7 +388,12 @@
     (with-clojure-buffer-point
         "(defn- |^{:doc \"A function\"} foo [] 1)
          (defn- ^:private bar 2)"
-        (expect (clojure-find-def) :to-equal '("defn-" "foo"))))
+        (expect (clojure-find-def) :to-equal '("defn-" "foo")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn- ^{:|a {}} complex-metadata |[x y z] z)
+         (def bar 2)"
+        (expect (clojure-find-def) :to-equal '("defn-" "complex-metadata"))))
   (it "should recognize def...-, with or without metadata"
     (with-clojure-buffer-point
         "(def foo 1)

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -375,7 +375,7 @@
          (deftest ^{:a {}} complex-metadata)
          (deftest |no-metadata)"
         (expect (clojure-find-def) :to-equal '("deftest" "no-metadata"))))
-  (it "should recognize defn-"
+  (it "should recognize defn-, with or without metadata"
     (with-clojure-buffer-point
         "(def foo 1)
          (defn- bar |[x y z] z)
@@ -388,7 +388,8 @@
     (with-clojure-buffer-point
         "(defn- |^{:doc \"A function\"} foo [] 1)
          (defn- ^:private bar 2)"
-        (expect (clojure-find-def) :to-equal '("defn-" "foo")))
+        (expect (clojure-find-def) :to-equal '("defn-" "foo"))))
+  (it "should recognize def...-, with or without metadata"
     (with-clojure-buffer-point
         "(def-n- |^{:doc \"A function\"} foo [] 1)
          (defn- ^:private bar 2)"

--- a/test/clojure-mode-util-test.el
+++ b/test/clojure-mode-util-test.el
@@ -374,7 +374,21 @@
         "(deftest ^{:a 1} simple-metadata)
          (deftest ^{:a {}} complex-metadata)
          (deftest |no-metadata)"
-        (expect (clojure-find-def) :to-equal '("deftest" "no-metadata")))))
+        (expect (clojure-find-def) :to-equal '("deftest" "no-metadata"))))
+  (it "should recognize defn-"
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn- bar |[x y z] z)
+         (def bar 2)"
+        (expect (clojure-find-def) :to-equal '("defn-" "bar")))
+    (with-clojure-buffer-point
+        "(def foo 1)
+         (defn- ^:private bar |[x y z] z)"
+        (expect (clojure-find-def) :to-equal '("defn-" "bar")))
+    (with-clojure-buffer-point
+        "(defn- |^{:doc \"A function\"} foo [] 1)
+         (defn- ^:private bar 2)"
+        (expect (clojure-find-def) :to-equal '("defn-" "foo")))))
 
 (provide 'clojure-mode-util-test)
 


### PR DESCRIPTION
This PR expands on the work of #682.

The problem is that when running `cider-find-def` with point inside the following function,
```clojure
(defn- foo [x] x)
```
it would not recognize `defn-` as the first symbol. Instead it would output `("defn" "-")`. I would expect it to output `("defn-" "foo")`.

This stems from the regex for declarations in `clojure-def-type-and-name-regex`:
https://github.com/clojure-emacs/clojure-mode/blob/63356ee3bd6903e7b17822022f5a6ded2512b979/clojure-mode.el#L2269

It recognizes `def` followed by an entry from the word class `w` or from the symbol class `_`, but it also states that the end must be from the "comment end" class `>`. The hyphen is not included in this class and therefore can't be the final character in the recognized expression.

My suggested fix is to recognize an optional hyphen at the end.

It still recognizes `def-n` and now also `def-n-`

I added a few test cases to the ones added by @frwdrik.

Emacs version:
GNU Emacs 30.0.92 (build 2, aarch64-apple-darwin24.1.0, NS appkit-2575.20 Version 15.1 (Build 24B83)) of 2024-11-01

`clojure-mode` version:
clojure-mode (version 5.20.0-snapshot)

-----------------

Before submitting a PR mark the checkboxes for the items you've done (if you
think a checkbox does not apply, then leave it unchecked):

- [x] The commits are consistent with our [contribution guidelines][1].
- [x] You've added tests (if possible) to cover your change(s). Bugfix, indentation, and font-lock tests are extremely important!
- [x] You've run `M-x checkdoc` and fixed any warnings in the code you've written.
- [ ] You've updated the changelog (if adding/changing user-visible functionality).
- [ ] You've updated the readme (if adding/changing user-visible functionality).

Thanks!

[1]: https://github.com/clojure-emacs/clojure-mode/blob/master/CONTRIBUTING.md
