### PR TITLE
Restore outline-regexp pattern for top-level forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [cider#3758](https://github.com/clojure-emacs/cider/issues/3758): Improve regexp for clojure-find-def to recognize more complex metadata on vars
+* [#684](https://github.com/clojure-emacs/clojure-mode/issues/684): Restore `outline-regexp` pattern to permit outline handling of top-level forms.
 
 ## 5.19.0 (2024-05-26)
 

--- a/clojure-mode.el
+++ b/clojure-mode.el
@@ -625,7 +625,7 @@ replacement for `cljr-expand-let`."
   (add-to-list 'imenu-generic-expression '(nil clojure-match-next-def 0))
   (setq-local indent-tabs-mode nil)
   (setq-local paragraph-ignore-fill-prefix t)
-  (setq-local outline-regexp ";;;;* ")
+  (setq-local outline-regexp ";;;;* \\|(") ; comments and top-level forms
   (setq-local outline-level 'lisp-outline-level)
   (setq-local comment-start ";")
   (setq-local comment-start-skip ";+ *")


### PR DESCRIPTION
Multiple alternate patterns were previously removed from `outline-regexp` in b1ea6de. This update restores the alternate pattern that enables top-level code forms to participate in `outline-minor-mode`.

Adding this pattern back in does not undo the fix to #550 intended in b1ea6de.

Closes #684